### PR TITLE
Update client.en.yml

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4,7 +4,7 @@ en:
       allow_accepted_answers: "Allow topic owner and staff to mark a reply as the solution"
       accept_answer: "This reply solves the problem"
       has_accepted_answer: "This topic has a solution"
-      unaccept_answer: "This reply no longer solves the problem"
+      unaccept_answer: "Marked solved by {{username}}. Click to mark unsolved."
       accepted_answer: "Solution"
       solution: "Solution"
       accepted_html: "<i class='fa-check-square fa accepted'></i> Solved <span class='by'>by <a href data-user-card='{{username_lower}}'>{{username}}</a></span> in <a href='{{post_path}}'>post #{{post_number}}</a>"


### PR DESCRIPTION
W.r.t. https://meta.discourse.org/t/see-who-marked-post-as-solved/37013

I haven't tested it yet. I simply took hints from the existing code. In the `accepted_notification` property, `{{username}}` is used to show the name of the person who marked the post solved. So, I have used the same style in the `unaccept_answer` property.

If the code is incorrect, please let me know why and I'll try to fix it! :) Thanks!
