### PR TITLE
Added empty box icon to unsolved topics

### DIFF
--- a/assets/javascripts/discourse/initializers/extend-for-solved-button.js.es6
+++ b/assets/javascripts/discourse/initializers/extend-for-solved-button.js.es6
@@ -223,6 +223,13 @@ export default {
             title: I18n.t('solved.has_accepted_answer'),
             icon: 'check-square-o'
           });
+        }else if(this.topic.can_have_answer && this.siteSettings.solved_enabled && this.siteSettings.empty_box_on_unsolved){
+          results.push({
+            openTag: 'span',
+            closeTag: 'span',
+            title: I18n.t('solved.no_accepted_answer'),
+            icon: 'square-o'
+          });
         }
         return results;
       }.property()

--- a/assets/javascripts/discourse/initializers/extend-for-solved-button.js.es6
+++ b/assets/javascripts/discourse/initializers/extend-for-solved-button.js.es6
@@ -227,7 +227,7 @@ export default {
           results.push({
             openTag: 'span',
             closeTag: 'span',
-            title: I18n.t('solved.no_accepted_answer'),
+            title: I18n.t('solved.has_no_accepted_answer'),
             icon: 'square-o'
           });
         }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5,6 +5,7 @@ en:
       allow_accepted_answers: "Allow topic owner and staff to mark a reply as the solution"
       accept_answer: "This reply solves the problem"
       has_accepted_answer: "This topic has a solution"
+      has_no_accepted_answer: "This topic has no solution"
       unaccept_answer: "This reply no longer solves the problem"
       accepted_answer: "Solution"
       solution: "Solution"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3,6 +3,7 @@ en:
     solved_enabled: "Enable solved plugin, allow users to select solutions for topics"
     allow_solved_on_all_topics: "Allow users to select solutions on all topics (by default you control this by editing categories)"
     accept_all_solutions_trust_level: "Minimum trust level required to accept solutions on any topic (even when not OP)"
+    empty_box_on_unsolved: "Display an empty box next to unsolved topics"
   reports:
     accepted_solutions:
       title: "Accepted solutions"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,3 +8,6 @@ plugins:
   accept_all_solutions_trust_level:
     default: 4
     client: true
+  empty_box_on_unsolved:
+    default: false
+    client: true

--- a/plugin.rb
+++ b/plugin.rb
@@ -340,16 +340,20 @@ SQL
   require_dependency 'topic_list_item_serializer'
 
   class ::TopicListItemSerializer
-    attributes :has_accepted_answer, :can_have_answer
+    attributes :has_accepted_answer
 
     def has_accepted_answer
       object.custom_fields["accepted_answer_post_id"] ? true : false
     end
 
-    def can_have_answer
-      return true if SiteSetting.allow_solved_on_all_topics
+    if SiteSetting.empty_box_on_unsolved
+      attributes :can_have_answer
 
-      return scope.allow_accepted_answers_on_category?(object.category_id)
+      def can_have_answer
+        return true if SiteSetting.allow_solved_on_all_topics
+
+        return scope.allow_accepted_answers_on_category?(object.category_id)
+      end
     end
   end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -340,10 +340,16 @@ SQL
   require_dependency 'topic_list_item_serializer'
 
   class ::TopicListItemSerializer
-    attributes :has_accepted_answer
+    attributes :has_accepted_answer, :can_have_answer
 
     def has_accepted_answer
       object.custom_fields["accepted_answer_post_id"] ? true : false
+    end
+
+    def can_have_answer
+      return true if SiteSetting.allow_solved_on_all_topics
+
+      return scope.allow_accepted_answers_on_category?(object.category_id)
     end
   end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -340,20 +340,16 @@ SQL
   require_dependency 'topic_list_item_serializer'
 
   class ::TopicListItemSerializer
-    attributes :has_accepted_answer
+    attributes :has_accepted_answer, :can_have_answer
 
     def has_accepted_answer
       object.custom_fields["accepted_answer_post_id"] ? true : false
     end
 
-    if SiteSetting.empty_box_on_unsolved
-      attributes :can_have_answer
+    def can_have_answer
+      return true if SiteSetting.allow_solved_on_all_topics
 
-      def can_have_answer
-        return true if SiteSetting.allow_solved_on_all_topics
-
-        return scope.allow_accepted_answers_on_category?(object.category_id)
-      end
+      return scope.allow_accepted_answers_on_category?(object.category_id)
     end
   end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -351,6 +351,10 @@ SQL
 
       return scope.allow_accepted_answers_on_category?(object.category_id)
     end
+
+    def include_can_have_answer?
+      SiteSetting.empty_box_on_unsolved
+    end
   end
 
   TopicList.preloaded_custom_fields << "accepted_answer_post_id" if TopicList.respond_to? :preloaded_custom_fields


### PR DESCRIPTION
Adds a setting which allows displaying an "Empty Box" on topics which are eligible to receive an answer, but have not yet been solved. Disabled by default, so should not affect existing setups.

<img width="318" alt="screen shot 2017-02-27 at 15 01 44" src="https://cloud.githubusercontent.com/assets/6270921/23366173/ad96d418-fcfd-11e6-925a-0752b0909164.png">
