### PR TITLE
Allow filtering by solved or unsolved

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -337,6 +337,27 @@ SQL
     end
   end
 
+  require_dependency 'topic_query'
+
+  TopicQuery.add_custom_filter(:solved) do |results, topic_query|
+    if topic_query.options[:solved] == 'true'
+      results = results.where("topics.id IN (
+        SELECT tc.topic_id
+        FROM topic_custom_fields tc
+        WHERE tc.name = 'accepted_answer_post_id' AND
+                        tc.value IS NOT NULL
+        )")
+    elsif topic_query.options[:solved] == 'false'
+      results = results.where("topics.id NOT IN (
+        SELECT tc.topic_id
+        FROM topic_custom_fields tc
+        WHERE tc.name = 'accepted_answer_post_id' AND
+                        tc.value IS NOT NULL
+        )")
+    end
+    results
+  end
+
   require_dependency 'topic_list_item_serializer'
 
   class ::TopicListItemSerializer


### PR DESCRIPTION
Adds a custom filter to TopicQuery which allows you to filter by solved or unsolved.

So you can do, for example:

    https://my.forum/latest?solved=true

or

    https://my.forum/latest?solved=true

This is better than just using the search filters, because you can see more than 50 topics in the list.

This depends on [discourse 74d4209](https://github.com/discourse/discourse/commit/74d4209d24adabfa94f8c0bfc513b14ebbdfadb8) so currently this code will break for anyone on 1.7 stable.