### PR TITLE
Check discourse version before adding TopicQuery filters

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -337,25 +337,27 @@ SQL
     end
   end
 
-  require_dependency 'topic_query'
+  if Discourse.has_needed_version?(Discourse::VERSION::STRING, '1.8.0.beta6')
+    require_dependency 'topic_query'
 
-  TopicQuery.add_custom_filter(:solved) do |results, topic_query|
-    if topic_query.options[:solved] == 'true'
-      results = results.where("topics.id IN (
-        SELECT tc.topic_id
-        FROM topic_custom_fields tc
-        WHERE tc.name = 'accepted_answer_post_id' AND
-                        tc.value IS NOT NULL
-        )")
-    elsif topic_query.options[:solved] == 'false'
-      results = results.where("topics.id NOT IN (
-        SELECT tc.topic_id
-        FROM topic_custom_fields tc
-        WHERE tc.name = 'accepted_answer_post_id' AND
-                        tc.value IS NOT NULL
-        )")
+    TopicQuery.add_custom_filter(:solved) do |results, topic_query|
+      if topic_query.options[:solved] == 'true'
+        results = results.where("topics.id IN (
+          SELECT tc.topic_id
+          FROM topic_custom_fields tc
+          WHERE tc.name = 'accepted_answer_post_id' AND
+                          tc.value IS NOT NULL
+          )")
+      elsif topic_query.options[:solved] == 'false'
+        results = results.where("topics.id NOT IN (
+          SELECT tc.topic_id
+          FROM topic_custom_fields tc
+          WHERE tc.name = 'accepted_answer_post_id' AND
+                          tc.value IS NOT NULL
+          )")
+      end
+      results
     end
-    results
   end
 
   require_dependency 'topic_list_item_serializer'


### PR DESCRIPTION
@SamSaffron my previous PR which was merged breaks discourse-solved on any Discourse before 1.8.0.beta6 (e.g. if someone is running 1.7 stable). This PR adds a version check before running the new code.

