### PR TITLE
Allow linking to filters within the site

### DIFF
--- a/assets/javascripts/discourse/initializers/extend-for-solved-button.js.es6
+++ b/assets/javascripts/discourse/initializers/extend-for-solved-button.js.es6
@@ -113,7 +113,9 @@ function initializeWithApi(api) {
 
   api.includePostAttributes('can_accept_answer', 'can_unaccept_answer', 'accepted_answer');
 
-  api.addDiscoveryQueryParam('solved', {replace: true, refreshModel: true});
+  if (api.addDiscoveryQueryParam) {
+    api.addDiscoveryQueryParam('solved', {replace: true, refreshModel: true});
+  }
 
   api.addPostMenuButton('solved', attrs => {
     const canAccept = attrs.can_accept_answer;

--- a/assets/javascripts/discourse/initializers/extend-for-solved-button.js.es6
+++ b/assets/javascripts/discourse/initializers/extend-for-solved-button.js.es6
@@ -113,6 +113,8 @@ function initializeWithApi(api) {
 
   api.includePostAttributes('can_accept_answer', 'can_unaccept_answer', 'accepted_answer');
 
+  api.addDiscoveryQueryParam('solved', {replace: true, refreshModel: true});
+
   api.addPostMenuButton('solved', attrs => {
     const canAccept = attrs.can_accept_answer;
     const canUnaccept = attrs.can_unaccept_answer;


### PR DESCRIPTION
Added addDiscoveryQueryParam for `solved` parameter.

https://meta.discourse.org/t/making-filters-work-without-reload/58049
