### PR TITLE
Change parameters from true/false to solved/unsolved.

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -341,14 +341,14 @@ SQL
     require_dependency 'topic_query'
 
     TopicQuery.add_custom_filter(:solved) do |results, topic_query|
-      if topic_query.options[:solved] == 'true'
+      if topic_query.options[:solved] == 'solved'
         results = results.where("topics.id IN (
           SELECT tc.topic_id
           FROM topic_custom_fields tc
           WHERE tc.name = 'accepted_answer_post_id' AND
                           tc.value IS NOT NULL
           )")
-      elsif topic_query.options[:solved] == 'false'
+      elsif topic_query.options[:solved] == 'unsolved'
         results = results.where("topics.id NOT IN (
           SELECT tc.topic_id
           FROM topic_custom_fields tc

--- a/plugin.rb
+++ b/plugin.rb
@@ -341,14 +341,14 @@ SQL
     require_dependency 'topic_query'
 
     TopicQuery.add_custom_filter(:solved) do |results, topic_query|
-      if topic_query.options[:solved] == 'solved'
+      if topic_query.options[:solved] == 'yes'
         results = results.where("topics.id IN (
           SELECT tc.topic_id
           FROM topic_custom_fields tc
           WHERE tc.name = 'accepted_answer_post_id' AND
                           tc.value IS NOT NULL
           )")
-      elsif topic_query.options[:solved] == 'unsolved'
+      elsif topic_query.options[:solved] == 'no'
         results = results.where("topics.id NOT IN (
           SELECT tc.topic_id
           FROM topic_custom_fields tc


### PR DESCRIPTION
Sorry @SamSaffron, got another one for you. 

Using 'true'/'false' in the query variables wasn't working, because Ember interpreted the default as False (wheras we need 3 states: solved, unsolved & all). I've changed the strings to 'solved'/'unsolved' to work around that issue.

https://discuss.emberjs.com/t/boolean-query-params/4301