### PR TITLE
Provide options for hiding posts before/after the solution

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4,6 +4,8 @@ en:
     allow_solved_on_all_topics: "Allow users to select solutions on all topics (by default you control this by editing categories)"
     accept_all_solutions_trust_level: "Minimum trust level required to accept solutions on any topic (even when not OP)"
     empty_box_on_unsolved: "Display an empty box next to unsolved topics"
+    hide_posts_before_solution: "Once a topic is solved, hide posts between the first post and the solution"
+    hide_posts_after_solution: "Once a topic is solved, hide posts after the solution"
   reports:
     accepted_solutions:
       title: "Accepted solutions"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,3 +11,9 @@ plugins:
   empty_box_on_unsolved:
     default: false
     client: true
+  hide_posts_before_solution:
+    default: false
+    client: false
+  hide_posts_after_solution:
+    default: false
+    client: false

--- a/plugin.rb
+++ b/plugin.rb
@@ -358,6 +358,33 @@ SQL
       end
       results
     end
+
+    require_dependency 'topic_view'
+    TopicView.add_custom_filter(:solved) do |results, topic_view|
+      
+      if SiteSetting.hide_posts_before_solution || SiteSetting.hide_posts_after_solution
+        
+        # Determine if the topic has an accepted answer
+        solution_post_id = topic_view.topic.custom_fields['accepted_answer_post_id']
+        has_accepted_answer = solution_post_id ? true : false
+
+        if has_accepted_answer
+          if SiteSetting.hide_posts_before_solution
+            results = results.where("post_number = 1 
+              OR post_number >= (SELECT post_number FROM posts WHERE id = ?)", solution_post_id)
+          end
+
+          if SiteSetting.hide_posts_after_solution
+            results = results.where("post_number = 1 
+              OR post_number <= (SELECT post_number FROM posts WHERE id = ?)", solution_post_id)
+          end
+        end
+
+      end
+
+      results
+    end
+
   end
 
   require_dependency 'topic_list_item_serializer'


### PR DESCRIPTION
# Depends on changes in core, but opened pull request for discussion/review

Provide functionality for collapsing posts before/after a solution, as described [here](https://meta.discourse.org/t/option-to-move-accepted-answer-to-the-top/58386)

Depends on https://github.com/discourse/discourse/pull/4740