### PR TITLE
FIX: deprecation warning on topic-status

### DIFF
--- a/assets/javascripts/discourse/initializers/extend-for-solved-button.js.es6
+++ b/assets/javascripts/discourse/initializers/extend-for-solved-button.js.es6
@@ -1,6 +1,6 @@
 import Topic from 'discourse/models/topic';
 import User from 'discourse/models/user';
-import TopicStatus from 'discourse/views/topic-status';
+import TopicStatus from 'discourse/raw-views/topic-status';
 import { popupAjaxError } from 'discourse/lib/ajax-error';
 import { withPluginApi } from 'discourse/lib/plugin-api';
 import { ajax } from 'discourse/lib/ajax';


### PR DESCRIPTION
Topic-status was moved in https://github.com/discourse/discourse/commit/f105d721297c2d2df2d9c19c674ba8563015df84 on 14th November (1.7.0beta7). Given 1.6 is no longer supported, I think it should be ok to fix this, and stop the deprecation warnings in the javascript console