### PR TITLE
FIX: Don't open a topic to set an auto-close timer when marking as so…

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -108,7 +108,7 @@ SQL
                           )
       end
 
-      if (auto_close_hours = SiteSetting.solved_topics_auto_close_hours) > 0
+      if (auto_close_hours = SiteSetting.solved_topics_auto_close_hours) > 0 and !topic.closed
         topic.set_or_create_timer(
           TopicTimer.types[:close],
           auto_close_hours,

--- a/spec/integration/solved_spec.rb
+++ b/spec/integration/solved_spec.rb
@@ -30,12 +30,15 @@ RSpec.describe "Managing Posts solved status" do
     it 'does not set a timer when the topic is closed' do
       topic2.update!(closed: true)
       xhr :post, "/solution/accept", id: p2.id 
-
-      expect(p2.reload.custom_fields["is_accepted_answer"]).to eq("true")
-
-      expect(topic2.reload.public_topic_timer).to eq(nil)
       
-      expect(topic2.reload.closed).to eq(true)
+      p2.reload
+      topic2.reload
+
+      expect(p2.custom_fields["is_accepted_answer"]).to eq("true")
+
+      expect(topic2.public_topic_timer).to eq(nil)
+      
+      expect(topic2.closed).to eq(true)
     end
   end
 end

--- a/spec/integration/solved_spec.rb
+++ b/spec/integration/solved_spec.rb
@@ -27,5 +27,15 @@ RSpec.describe "Managing Posts solved status" do
 
       expect(topic.public_topic_timer.based_on_last_post).to eq(true)
     end
+    it 'does not set a timer when the topic is closed' do
+      topic2.update!(closed: true)
+      xhr :post, "/solution/accept", id: p2.id 
+
+      expect(p2.reload.custom_fields["is_accepted_answer"]).to eq("true")
+
+      expect(topic2.reload.public_topic_timer).to eq(nil)
+      
+      expect(topic2.reload.closed).to eq(true)
+    end
   end
 end


### PR DESCRIPTION
…lved.

Fixes this issue: https://meta.discourse.org/t/marking-closed-topic-solved-with-solve-topics-auto-close-hours-set-causes-topic-to-be-reopened/63593?u=jomaxro

Topics that were closed before being marked as solved would be reopened and have an auto-close timer set.  If a topic is already closed, marking as solved should not cause it to re-open.