### PR TITLE
FEATURE: hide excerpt if 'solved_quote_length' is set to zero

### DIFF
--- a/assets/javascripts/discourse/initializers/extend-for-solved-button.js.es6
+++ b/assets/javascripts/discourse/initializers/extend-for-solved-button.js.es6
@@ -102,8 +102,9 @@ function initializeWithApi(api) {
       if (postModel) {
         const topic = postModel.get('topic');
         if (topic.get('accepted_answer')) {
+          const hasExcerpt = !!topic.get('accepted_answer').excerpt;
 
-          var rawhtml = `
+          const withExcerpt = `
             <aside class='quote' data-post="${topic.get('accepted_answer').post_number}" data-topic="${topic.get('id')}">
               <div class='title'>
                 ${topic.get('acceptedAnswerHtml')} <div class="quote-controls"><\/div>
@@ -113,7 +114,14 @@ function initializeWithApi(api) {
               </blockquote>
             </aside>`;
 
-          var cooked = new PostCooked({cooked:rawhtml});
+          const withoutExcerpt = `
+            <aside class='quote'>
+              <div class='title title-only'>
+                ${topic.get('acceptedAnswerHtml')}
+              </div>
+            </aside>`;
+
+          var cooked = new PostCooked({ cooked: hasExcerpt ? withExcerpt : withoutExcerpt });
 
           var html = cooked.init();
 

--- a/assets/stylesheets/solutions.scss
+++ b/assets/stylesheets/solutions.scss
@@ -38,3 +38,7 @@
   //border-top: 1px solid #ddd;
   //background-color: #E9FFE0;
 }
+
+aside.quote .title.title-only {
+  padding: 12px;
+}

--- a/plugin.rb
+++ b/plugin.rb
@@ -250,7 +250,11 @@ SQL
         .first
 
       if postInfo
-        postInfo[2] = PrettyText.excerpt(postInfo[2], SiteSetting.solved_quote_length)
+        postInfo[2] = if SiteSetting.solved_quote_length > 0
+                        PrettyText.excerpt(postInfo[2], SiteSetting.solved_quote_length)
+                      else
+                        nil
+                      end
         return postInfo
       end
     end

--- a/test/javascripts/acceptance/discourse-solved-test.js.es6
+++ b/test/javascripts/acceptance/discourse-solved-test.js.es6
@@ -1,0 +1,37 @@
+import { acceptance } from "helpers/qunit-helpers";
+
+acceptance('Discourse Solved Plugin', {
+  loggedIn: true,
+  beforeEach() {
+    const response = object => {
+      return [200, { "Content-Type": "application/json" }, object];
+    };
+
+    const postStreamWithAcceptedAnswerExcerpt = excerpt => {
+      return {"post_stream":{"posts":[{"id":21,"name":null,"username":"kzh","avatar_template":"/letter_avatar_proxy/v2/letter/k/ac91a4/{size}.png","created_at":"2017-08-08T20:11:32.542Z","cooked":"<p>How do I declare a variable in ruby?</p>","post_number":1,"post_type":1,"updated_at":"2017-08-08T21:03:30.521Z","reply_count":0,"reply_to_post_number":null,"quote_count":0,"avg_time":null,"incoming_link_count":0,"reads":1,"score":0,"yours":true,"topic_id":23,"topic_slug":"test-solved","display_username":null,"primary_group_name":null,"primary_group_flair_url":null,"primary_group_flair_bg_color":null,"primary_group_flair_color":null,"version":2,"can_edit":true,"can_delete":false,"can_recover":null,"can_wiki":true,"read":true,"user_title":null,"actions_summary":[{"id":3,"can_act":true},{"id":4,"can_act":true},{"id":5,"hidden":true,"can_act":true},{"id":7,"can_act":true},{"id":8,"can_act":true}],"moderator":false,"admin":true,"staff":true,"user_id":1,"hidden":false,"hidden_reason_id":null,"trust_level":4,"deleted_at":null,"user_deleted":false,"edit_reason":null,"can_view_edit_history":true,"wiki":false,"can_accept_answer":false,"can_unaccept_answer":false,"accepted_answer":false},{"id":22,"name":null,"username":"kzh","avatar_template":"/letter_avatar_proxy/v2/letter/k/ac91a4/{size}.png","created_at":"2017-08-08T20:12:04.657Z","cooked":"<p>this is a long answer that potentially solves the question</p>","post_number":2,"post_type":1,"updated_at":"2017-08-08T21:20:24.417Z","reply_count":0,"reply_to_post_number":null,"quote_count":0,"avg_time":null,"incoming_link_count":0,"reads":1,"score":0,"yours":true,"topic_id":23,"topic_slug":"test-solved","display_username":null,"primary_group_name":null,"primary_group_flair_url":null,"primary_group_flair_bg_color":null,"primary_group_flair_color":null,"version":2,"can_edit":true,"can_delete":true,"can_recover":null,"can_wiki":true,"read":true,"user_title":null,"actions_summary":[{"id":3,"can_act":true},{"id":4,"can_act":true},{"id":5,"hidden":true,"can_act":true},{"id":7,"can_act":true},{"id":8,"can_act":true}],"moderator":false,"admin":true,"staff":true,"user_id":1,"hidden":false,"hidden_reason_id":null,"trust_level":4,"deleted_at":null,"user_deleted":false,"edit_reason":null,"can_view_edit_history":true,"wiki":false,"can_accept_answer":false,"can_unaccept_answer":true,"accepted_answer":true}],"stream":[21,22]},"timeline_lookup":[[1,0]],"id":23,"title":"Test solved","fancy_title":"Test solved","posts_count":2,"created_at":"2017-08-08T20:11:32.098Z","views":6,"reply_count":0,"participant_count":1,"like_count":0,"last_posted_at":"2017-08-08T20:12:04.657Z","visible":true,"closed":false,"archived":false,"has_summary":false,"archetype":"regular","slug":"test-solved","category_id":1,"word_count":18,"deleted_at":null,"pending_posts_count":0,"user_id":1,"pm_with_non_human_user":false,"draft":null,"draft_key":"topic_23","draft_sequence":6,"posted":true,"unpinned":null,"pinned_globally":false,"pinned":false,"pinned_at":null,"pinned_until":null,"details":{"created_by":{"id":1,"username":"kzh","avatar_template":"/letter_avatar_proxy/v2/letter/k/ac91a4/{size}.png"},"last_poster":{"id":1,"username":"kzh","avatar_template":"/letter_avatar_proxy/v2/letter/k/ac91a4/{size}.png"},"participants":[{"id":1,"username":"kzh","avatar_template":"/letter_avatar_proxy/v2/letter/k/ac91a4/{size}.png","post_count":2,"primary_group_name":null,"primary_group_flair_url":null,"primary_group_flair_color":null,"primary_group_flair_bg_color":null}],"notification_level":3,"notifications_reason_id":1,"can_move_posts":true,"can_edit":true,"can_delete":true,"can_remove_allowed_users":true,"can_invite_to":true,"can_invite_via_email":true,"can_create_post":true,"can_reply_as_new_topic":true,"can_flag_topic":true},"highest_post_number":2,"last_read_post_number":2,"last_read_post_id":22,"deleted_by":null,"has_deleted":false,"actions_summary":[{"id":4,"count":0,"hidden":false,"can_act":true},{"id":7,"count":0,"hidden":false,"can_act":true},{"id":8,"count":0,"hidden":false,"can_act":true}],"chunk_size":20,"bookmarked":false,"tags":[],"featured_link":null,"topic_timer":null,"message_bus_last_id":0,"accepted_answer":{"post_number":2,"username":"kzh","excerpt":excerpt}};
+    };
+
+    server.get('/t/11.json', () => { // eslint-disable-line no-undef
+      return response(postStreamWithAcceptedAnswerExcerpt("this is an excerpt"));
+    });
+
+    server.get('/t/12.json', () => { // eslint-disable-line no-undef
+      return response(postStreamWithAcceptedAnswerExcerpt(null));
+    });
+  }
+});
+
+test('A topic with an accepted answer shows an excerpt of the answer, if provided', assert => {
+  visit("/t/with-excerpt/11");
+
+  andThen(() => {
+    assert.ok(exists('.quote blockquote:contains("this is an excerpt")'));
+  });
+
+  visit("/t/without-excerpt/12");
+
+  andThen(() => {
+    assert.notOk(exists('.quote blockquote'));
+    assert.ok(exists('.quote .title.title-only'));
+  });
+});


### PR DESCRIPTION
> This PR resolves https://meta.discourse.org/t/remove-quote-of-the-solution-if-solved-quote-length-is-set-to-zero/61106

This new feature hides the excerpt for accepted answers if `solved_quote_length` has been set to zero, as per the discussion linked above.

---
### Screenshots

**`solved_quote_length := 0`**

<img width="600" alt="excerpt_length_0" src="https://user-images.githubusercontent.com/6376558/29139185-0456c4ca-7d14-11e7-95be-e40f51b16c58.png">

---

**`solved_quote_length := 10`**

<img width="600" alt="excerpt_length_10" src="https://user-images.githubusercontent.com/6376558/29139189-06b42802-7d14-11e7-950d-2142a2ed43e2.png">

---