### PR TITLE
FEATURE: Add helpdesk and tech support badges

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -16,3 +16,9 @@ en:
     no_solutions:
       self: "You have no accepted solutions yet."
       others: "No accepted solutions."
+  
+  badges:
+    helpdesk:
+      description: "First Accepted Answer on a Topic"
+    tech_support:
+      description: "10 Accepted answers"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -19,6 +19,8 @@ en:
   
   badges:
     helpdesk:
+      name: "Helpdesk"
       description: "First Accepted Answer on a Topic"
     tech_support:
+      name: "Tech Support"
       description: "10 Accepted answers"

--- a/db/fixtures/001_badges.rb
+++ b/db/fixtures/001_badges.rb
@@ -25,7 +25,7 @@ WHERE p.post_number > 1 AND
 EOS
 
 Badge.seed(:name) do |badge|
-  badge.name = "Helpdesk"
+  badge.name = I18n.t("badges.helpdesk.name")
   badge.icon = "check-square"
   badge.badge_type_id = 3
   badge.badge_grouping = badge_grouping
@@ -61,7 +61,7 @@ WHERE id  IN (
 EOS
 
 Badge.seed(:name) do |badge|
-  badge.name = "Tech Support"
+  badge.name = I18n.t("badges.tech_support.name")
   badge.icon = "check-square"
   badge.badge_type_id = 2
   badge.badge_grouping = badge_grouping

--- a/db/fixtures/001_badges.rb
+++ b/db/fixtures/001_badges.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+return unless badge_grouping = BadgeGrouping.find_by(name: "Community")
+
+helpdesk_query = <<-EOS
+SELECT p.user_id, p.id post_id, p.updated_at granted_at
+FROM badge_posts p
+WHERE p.post_number > 1 AND
+    p.id IN (
+      SELECT post_id FROM (
+       SELECT pc.post_id, row_number()
+       OVER (PARTITION BY p1.user_id ORDER BY pc.created_at) as rnum
+       FROM post_custom_fields pc
+       JOIN badge_posts p1 ON p1.id = pc.post_id
+       JOIN topics t1 ON p1.topic_id = t1.id
+       WHERE name = 'is_accepted_answer' AND
+                    p1.user_id <> t1.user_id AND
+        (
+          :backfill OR
+           p1.user_id IN (
+                   select user_id from posts where p1.id IN (:post_ids)
+           )
+       )
+) X  WHERE rnum = 1)
+EOS
+
+Badge.seed(:name) do |badge|
+  badge.name = "Helpdesk"
+  badge.icon = "check-square"
+  badge.badge_type_id = 3
+  badge.badge_grouping = badge_grouping
+  badge.description = I18n.t("badges.helpdesk.description")
+  badge.query = helpdesk_query
+  badge.listable = true
+  badge.target_posts = true
+  badge.enabled = false
+  badge.trigger = Badge::Trigger::PostRevision
+  badge.auto_revoke = true
+  badge.show_posts = true
+  badge.system = false
+end
+
+tech_support_query = <<-EOS
+SELECT id user_id, current_timestamp granted_at
+FROM users
+WHERE id  IN (
+       SELECT p1.user_id
+       FROM post_custom_fields pc
+       JOIN badge_posts p1 ON p1.id = pc.post_id
+       JOIN topics t1 ON p1.topic_id = t1.id
+       WHERE p1.user_id <> t1.user_id AND
+                    name = 'is_accepted_answer' AND
+            p1.user_id IN (
+                   SELECT user_id
+                   FROM posts
+                   WHERE :backfill OR  p1.id IN (:post_ids)
+            )
+        GROUP BY p1.user_id
+        HAVING COUNT(*) > 9
+)
+EOS
+
+Badge.seed(:name) do |badge|
+  badge.name = "Tech Support"
+  badge.icon = "check-square"
+  badge.badge_type_id = 2
+  badge.badge_grouping = badge_grouping
+  badge.description = I18n.t("badges.tech_support.description")
+  badge.query = tech_support_query
+  badge.listable = true
+  badge.allow_title = true
+  badge.target_posts = false
+  badge.enabled = false
+  badge.trigger = Badge::Trigger::PostRevision
+  badge.auto_revoke = true
+  badge.show_posts = false
+  badge.system = false
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -20,6 +20,7 @@ register_asset 'stylesheets/solutions.scss'
 register_asset 'stylesheets/mobile/solutions.scss', :mobile
 
 after_initialize do
+  SeedFu.fixture_paths << Rails.root.join("plugins", "discourse-solved", "db", "fixtures").to_s
 
   [
     '../app/serializers/concerns/topic_answer_mixin.rb'


### PR DESCRIPTION
When plugin is installed, we should create helpdesk and tech support
badges.

Both badges should be disabled by default