### PR TITLE
FEATURE: Publish WebHook event when solving/unsolving

### DIFF
--- a/assets/javascripts/discourse/initializers/extend-for-solved-button.js.es6
+++ b/assets/javascripts/discourse/initializers/extend-for-solved-button.js.es6
@@ -9,6 +9,7 @@ import PostCooked from "discourse/widgets/post-cooked";
 import { formatUsername } from "discourse/lib/utilities";
 import { iconHTML } from "discourse-common/lib/icon-library";
 import { iconNode } from "discourse-common/lib/icon-library";
+import SearchAdvancedOptions from "discourse/components/search-advanced-options";
 
 function clearAccepted(topic) {
   const posts = topic.get("postStream.posts");
@@ -260,6 +261,16 @@ export default {
         }
         return results;
       })
+    });
+
+    SearchAdvancedOptions.reopen({
+      didInsertElement() {
+        this._super();
+        this.statusOptions.push({
+          name: I18n.t("search.advanced.statuses.solved"),
+          value: "solved"
+        });
+      }
     });
 
     withPluginApi("0.1", initializeWithApi);

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -32,3 +32,9 @@ en:
       advanced:
         statuses:
           solved: "are solved"
+
+    admin:
+      web_hooks:
+        solved_event:
+          name: "Solved Event"
+          details: "When a user marks a post as the accepted or unaccepted answer."

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -27,3 +27,8 @@ en:
     topic_statuses:
       solved:
         help: "This topic has a solution"
+
+    search:
+      advanced:
+        statuses:
+          solved: "are solved"

--- a/db/fixtures/002_web_hook_event_types.rb
+++ b/db/fixtures/002_web_hook_event_types.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+WebHookEventType.seed do |b|
+  b.id = WebHookEventType::SOLVED
+  b.name = "solved"
+end

--- a/db/fixtures/002_web_hook_event_types.rb
+++ b/db/fixtures/002_web_hook_event_types.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-WebHookEventType.seed do |b|
-  b.id = WebHookEventType::SOLVED
-  b.name = "solved"
-end

--- a/plugin.rb
+++ b/plugin.rb
@@ -21,10 +21,6 @@ register_asset 'stylesheets/mobile/solutions.scss', :mobile
 
 after_initialize do
 
-  class ::WebHookEventType
-    SOLVED = 100.freeze
-  end
-
   SeedFu.fixture_paths << Rails.root.join("plugins", "discourse-solved", "db", "fixtures").to_s
 
   [

--- a/plugin.rb
+++ b/plugin.rb
@@ -465,7 +465,7 @@ SQL
 
   #TODO Remove when plugin is 1.0
   if Search.respond_to? :advanced_filter
-    Search.advanced_filter(/in:solved/) do |posts|
+    Search.advanced_filter(/status:solved/) do |posts|
       posts.where("topics.id IN (
         SELECT tc.topic_id
         FROM topic_custom_fields tc
@@ -475,7 +475,7 @@ SQL
 
     end
 
-    Search.advanced_filter(/in:unsolved/) do |posts|
+    Search.advanced_filter(/status:unsolved/) do |posts|
       posts.where("topics.id NOT IN (
         SELECT tc.topic_id
         FROM topic_custom_fields tc

--- a/plugin.rb
+++ b/plugin.rb
@@ -138,6 +138,11 @@ SQL
       topic.save!
       post.save!
 
+      if WebHook.active_web_hooks(:post).exists?
+        payload = WebHook.generate_payload(:post, post)
+        WebHook.enqueue_post_hooks(:post_edited, post, payload)
+      end
+
       DiscourseEvent.trigger(:accepted_solution, post)
     end
 
@@ -172,6 +177,12 @@ SQL
       )
 
       notification.destroy! if notification
+
+      if WebHook.active_web_hooks(:post).exists?
+        payload = WebHook.generate_payload(:post, post)
+        WebHook.enqueue_post_hooks(:post_edited, post, payload)
+      end
+
       DiscourseEvent.trigger(:unaccepted_solution, post)
     end
   end

--- a/spec/fabricators/solved_hook_fabricator.rb
+++ b/spec/fabricators/solved_hook_fabricator.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Fabricator(:solved_web_hook, from: :web_hook) do
+  transient solved_hook: WebHookEventType.find_by(name: 'solved')
+
+  after_build do |web_hook, transients|
+    web_hook.web_hook_event_types = [transients[:solved_hook]]
+  end
+end


### PR DESCRIPTION
This feature will publish a post edit webhook event whenever a solution
is accepted or unaccepted.

I went ahead and used the existing post-edit webhook because all the
post custom fields for the solved plugin are already included in the
post-edit serializer.