### PR TITLE
Advanced search option - unsolved

### DIFF
--- a/assets/javascripts/discourse/initializers/extend-for-solved-button.js.es6
+++ b/assets/javascripts/discourse/initializers/extend-for-solved-button.js.es6
@@ -270,6 +270,10 @@ export default {
           name: I18n.t("search.advanced.statuses.solved"),
           value: "solved"
         });
+        this.statusOptions.push({
+          name: I18n.t("search.advanced.statuses.unsolved"),
+          value: "unsolved"
+        });
       }
     });
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -32,6 +32,7 @@ en:
       advanced:
         statuses:
           solved: "are solved"
+          unsolved: "are unsolved"
 
     admin:
       web_hooks:


### PR DESCRIPTION
New users find it difficult to use the search query directly and trying `status:unsolved`.