### PR TITLE
Improve solved topics auto close hours description

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5,7 +5,7 @@ en:
     accept_all_solutions_trust_level: "Minimum trust level required to accept solutions on any topic (even when not OP)"
     empty_box_on_unsolved: "Display an empty box next to unsolved topics"
     solved_quote_length: "Number of characters to quote when displaying the solution under the first post"
-    solved_topics_auto_close_hours: "Auto close topic (n) hours after the last reply once the topic has been marked as solved"
+    solved_topics_auto_close_hours: "Auto close topic (n) hours after the last reply once the topic has been marked as solved. Set to 0 to disable auto closing."
     show_filter_by_solved_status: "Show a dropdown to filter a topic list by solved status."
   reports:
     accepted_solutions:
@@ -16,7 +16,7 @@ en:
     no_solutions:
       self: "You have no accepted solutions yet."
       others: "No accepted solutions."
-  
+
   badges:
     helpdesk:
       name: "Helpdesk"


### PR DESCRIPTION
The copy change makes it clear that when set to 0 topics will not be auto closed. Possibly I'm the only person who has been confused by the setting though. This is related to looking at issues mentioned here: https://meta.discourse.org/t/solved-topics-not-autoclosing/166708/12.

One thing to note with this setting is that it accepts a float, for example 0.1. When set to a float, the float will be displayed in the settings field, but Discourse will round it down to the nearest integer when using the setting. This means that setting it to anything less than 1 will prevent topics from being auto closed. I'm not sure if this needs to be fixed - I think it's too much detail to give in the setting's description though.