### PR TITLE
FEATURE: send notification to OP when staff marked a post as solution.

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -7,7 +7,7 @@ en:
     solved_quote_length: "Number of characters to quote when displaying the solution under the first post"
     solved_topics_auto_close_hours: "Auto close topic (n) hours after the last reply once the topic has been marked as solved. Set to 0 to disable auto closing."
     show_filter_by_solved_status: "Show a dropdown to filter a topic list by solved status."
-    notify_op_on_staff_accept: "Send notification to OP when a post is marked as solution by a staff."
+    notify_on_staff_accept_solved: "Send notification to the topic creator when a post is marked as solution by a staff."
   reports:
     accepted_solutions:
       title: "Accepted solutions"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -7,6 +7,7 @@ en:
     solved_quote_length: "Number of characters to quote when displaying the solution under the first post"
     solved_topics_auto_close_hours: "Auto close topic (n) hours after the last reply once the topic has been marked as solved. Set to 0 to disable auto closing."
     show_filter_by_solved_status: "Show a dropdown to filter a topic list by solved status."
+    notify_op_on_staff_accept: "Send notification to OP when a post is marked as solution by a staff."
   reports:
     accepted_solutions:
       title: "Accepted solutions"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,5 +19,5 @@ plugins:
   show_filter_by_solved_status:
     default: false
     client: true
-  notify_op_on_staff_accept:
+  notify_on_staff_accept_solved:
     default: false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,3 +19,5 @@ plugins:
   show_filter_by_solved_status:
     default: false
     client: true
+  notify_op_on_staff_accept:
+    default: false

--- a/plugin.rb
+++ b/plugin.rb
@@ -108,17 +108,29 @@ SQL
           )
         end
 
+        notification_data = {
+          message: 'solved.accepted_notification',
+          display_username: acting_user.username,
+          topic_title: topic.title
+        }.to_json
+
         unless acting_user.id == post.user_id
           Notification.create!(
             notification_type: Notification.types[:custom],
             user_id: post.user_id,
             topic_id: post.topic_id,
             post_number: post.post_number,
-            data: {
-              message: 'solved.accepted_notification',
-              display_username: acting_user.username,
-              topic_title: topic.title
-            }.to_json
+            data: notification_data
+          )
+        end
+
+        if SiteSetting.notify_op_on_staff_accept && acting_user.id != topic.user_id
+          Notification.create!(
+            notification_type: Notification.types[:custom],
+            user_id: topic.user_id,
+            topic_id: post.topic_id,
+            post_number: post.post_number,
+            data: notification_data
           )
         end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -124,7 +124,7 @@ SQL
           )
         end
 
-        if SiteSetting.notify_op_on_staff_accept && acting_user.id != topic.user_id
+        if SiteSetting.notify_on_staff_accept_solved && acting_user.id != topic.user_id
           Notification.create!(
             notification_type: Notification.types[:custom],
             user_id: topic.user_id,

--- a/spec/integration/solved_spec.rb
+++ b/spec/integration/solved_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "Managing Posts solved status" do
     end
 
     it 'sends notifications to correct users' do
-      SiteSetting.notify_op_on_staff_accept = true
+      SiteSetting.notify_on_staff_accept_solved = true
       user = Fabricate(:user)
       topic = Fabricate(:topic, user: user)
       post = Fabricate(:post, post_number: 2, topic: topic)


### PR DESCRIPTION
Previously, we won't send any notification to original poster when a staff user marked a post as the solution behalf of OP.