### PR TITLE
UX: Do not render solved filter on categories page

### DIFF
--- a/assets/javascripts/discourse/connectors/bread-crumbs-right/solved-status-filter.hbs
+++ b/assets/javascripts/discourse/connectors/bread-crumbs-right/solved-status-filter.hbs
@@ -3,7 +3,7 @@
     class="solved-status-filter"
     content=statuses
     value=status
-    valueAttribute="value"
-    onSelect=(action "changeStatus")
+    valueProperty="value"
+    onChange=(action "changeStatus")
   }}
 {{/if}}

--- a/assets/javascripts/discourse/connectors/bread-crumbs-right/solved-status-filter.js.es6
+++ b/assets/javascripts/discourse/connectors/bread-crumbs-right/solved-status-filter.js.es6
@@ -3,7 +3,8 @@ import DiscourseUrl from "discourse/lib/url";
 
 export default {
   shouldRender(args, component) {
-    const router = Discourse.__container__.lookup("router:main");
+    const register = component.store.register;
+    const router = register.lookup("router:main");
 
     if (
       !component.siteSettings.show_filter_by_solved_status ||
@@ -13,10 +14,7 @@ export default {
     } else if (component.siteSettings.allow_solved_on_all_topics) {
       return true;
     } else {
-      const controller = Discourse.__container__.lookup(
-        "controller:navigation/category"
-      );
-
+      const controller = register.lookup("controller:navigation/category");
       return controller && controller.get("category.enable_accepted_answers");
     }
   },

--- a/assets/javascripts/discourse/connectors/bread-crumbs-right/solved-status-filter.js.es6
+++ b/assets/javascripts/discourse/connectors/bread-crumbs-right/solved-status-filter.js.es6
@@ -3,7 +3,12 @@ import DiscourseUrl from "discourse/lib/url";
 
 export default {
   shouldRender(args, component) {
-    if (!component.siteSettings.show_filter_by_solved_status) {
+    const router = Discourse.__container__.lookup("router:main");
+
+    if (
+      !component.siteSettings.show_filter_by_solved_status ||
+      router.currentPath === "discovery.categories"
+    ) {
       return false;
     } else if (component.siteSettings.allow_solved_on_all_topics) {
       return true;

--- a/assets/javascripts/discourse/connectors/bread-crumbs-right/solved-status-filter.js.es6
+++ b/assets/javascripts/discourse/connectors/bread-crumbs-right/solved-status-filter.js.es6
@@ -1,10 +1,10 @@
 import I18n from "I18n";
 import DiscourseUrl from "discourse/lib/url";
+import { getOwner } from "discourse-common/lib/get-owner";
 
 export default {
   shouldRender(args, component) {
-    const register = component.store.register;
-    const router = register.lookup("router:main");
+    const router = getOwner(this).lookup("router:main");
 
     if (
       !component.siteSettings.show_filter_by_solved_status ||
@@ -14,7 +14,9 @@ export default {
     } else if (component.siteSettings.allow_solved_on_all_topics) {
       return true;
     } else {
-      const controller = register.lookup("controller:navigation/category");
+      const controller = getOwner(this).lookup(
+        "controller:navigation/category"
+      );
       return controller && controller.get("category.enable_accepted_answers");
     }
   },


### PR DESCRIPTION
There is no topic list to filter on the categories page, so we should not be rendering the solved filter there.

This also addresses two deprecation notices:

<img width="752" alt="Screen Shot 2020-11-04 at 6 39 03 PM" src="https://user-images.githubusercontent.com/22733864/98190990-18e93e00-1ecd-11eb-8681-9d9e782e3ad2.png">
