### PR TITLE
FEATURE: silently auto close solved topic

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -137,22 +137,13 @@ SQL
         auto_close_hours = SiteSetting.solved_topics_auto_close_hours
 
         if (auto_close_hours > 0) && !topic.closed
-          begin
-            topic_timer = topic.set_or_create_timer(
-              TopicTimer.types[:close],
-              nil,
-              based_on_last_post: true,
-              duration: auto_close_hours
-            )
-          rescue ArgumentError
-            # https://github.com/discourse/discourse/commit/aad12822b7d7c9c6ecd976e23d3a83626c052dce#diff-4d0afa19fa7752955f36089bca420ab4L1135
-            # this rescue block can be deleted after discourse stable version > 2.4
-            topic_timer = topic.set_or_create_timer(
-              TopicTimer.types[:close],
-              auto_close_hours,
-              based_on_last_post: true
-            )
-          end
+          topic_timer = topic.set_or_create_timer(
+            # Fallback to TopicTimer.types[:close] can be removed after discourse stable version > 2.7
+            TopicTimer.types[:silent_close] || TopicTimer.types[:close],
+            nil,
+            based_on_last_post: true,
+            duration: auto_close_hours
+          )
 
           topic.custom_fields[
             AUTO_CLOSE_TOPIC_TIMER_CUSTOM_FIELD

--- a/spec/integration/solved_spec.rb
+++ b/spec/integration/solved_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "Managing Posts solved status" do
       expect(p1.reload.custom_fields["is_accepted_answer"]).to eq("true")
 
       expect(topic.public_topic_timer.status_type)
-        .to eq(TopicTimer.types[:close])
+        .to eq(TopicTimer.types[:silent_close])
 
       expect(topic.custom_fields[
         DiscourseSolved::AUTO_CLOSE_TOPIC_TIMER_CUSTOM_FIELD


### PR DESCRIPTION
Topic solved should be closed silently as system user involvement may be confusing.

In addition, old rescue block was dropped.

Meta: https://meta.discourse.org/t/discourse-encrypt-unable-to-see-close-message/135235