### PR TITLE
FIX: Refresh whole post stream when category changes

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -602,4 +602,14 @@ SQL
       SQL
     })
   end
+
+  on(:before_post_publish_changes) do |post_changes, topic_changes, options|
+    category_id_changes = topic_changes.diff["category_id"]
+    next if category_id_changes.blank?
+
+    old_category_allows = Guardian.new.allow_accepted_answers_on_category?(category_id_changes[0])
+    new_category_allows = Guardian.new.allow_accepted_answers_on_category?(category_id_changes[1])
+
+    options[:refresh_stream] = true if old_category_allows != new_category_allows
+  end
 end

--- a/spec/components/post_revisor_spec.rb
+++ b/spec/components/post_revisor_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'post_revisor'
+
+describe PostRevisor do
+  fab!(:category) { Fabricate(:category_with_definition) }
+
+  fab!(:category_solved) do
+    category = Fabricate(:category_with_definition)
+    category.upsert_custom_fields("enable_accepted_answers" => "true")
+    category
+  end
+
+  it "refreshes post stream when topic category changes to a solved category" do
+    topic = Fabricate(:topic, category: Fabricate(:category_with_definition))
+    post = Fabricate(:post, topic: topic)
+
+    messages = MessageBus.track_publish("/topic/#{topic.id}") do
+      described_class.new(post).revise!(Fabricate(:admin), { category_id: category.id })
+    end
+
+    expect(messages.first.data[:refresh_stream]).to eq(nil)
+
+    messages = MessageBus.track_publish("/topic/#{topic.id}") do
+      described_class.new(post).revise!(Fabricate(:admin), { category_id: category_solved.id })
+    end
+
+    expect(messages.first.data[:refresh_stream]).to eq(true)
+  end
+end


### PR DESCRIPTION
Moving a topic between categories did not update the 'Mark as solution' controls too. This fix applies only if the old and new category have different 'solved' settings.