### PR TITLE
FIX: Update set_or_create_topic_timer to use duration_minutes keyword

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -142,7 +142,7 @@ SQL
             TopicTimer.types[:silent_close] || TopicTimer.types[:close],
             nil,
             based_on_last_post: true,
-            duration: auto_close_hours
+            duration_minutes: auto_close_hours * 60
           )
 
           topic.custom_fields[


### PR DESCRIPTION
DO NOT MERGE UNTIL https://github.com/discourse/discourse/pull/11961 IS MERGED