### PR TITLE
FIX: Add min/max values for auto close hours

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,6 +16,8 @@ plugins:
     client: false
   solved_topics_auto_close_hours:
     default: 0
+    min: 0
+    max: 175200 # 20 years
   show_filter_by_solved_status:
     default: false
     client: true

--- a/db/migrate/20210218022053_solved_fix_high_auto_close_topic_hours.rb
+++ b/db/migrate/20210218022053_solved_fix_high_auto_close_topic_hours.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+class SolvedFixHighAutoCloseTopicHours < ActiveRecord::Migration[6.0]
+  def up
+    execute <<-SQL
+      UPDATE site_settings
+         SET value = '175000'
+       WHERE name = 'solved_topics_auto_close_hours'
+         AND CAST(value AS INT) > 175000
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
* Also add migration to cap current site settings for
solved_topics_auto_close_hours
  to the max of 175000 if they are too high

See https://github.com/discourse/discourse/commit/e0f0fe5624298021bbbb7845c12bf1582767631d