### PR TITLE
FEATURE: show education message in composer when replying on solved topic

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -8,6 +8,7 @@ en:
     solved_topics_auto_close_hours: "Auto close topic (n) hours after the last reply once the topic has been marked as solved. Set to 0 to disable auto closing."
     show_filter_by_solved_status: "Show a dropdown to filter a topic list by solved status."
     notify_on_staff_accept_solved: "Send notification to the topic creator when a post is marked as solution by a staff."
+    disable_solved_education_message: "Disable education message for solved topics."
   reports:
     accepted_solutions:
       title: "Accepted solutions"
@@ -25,3 +26,15 @@ en:
     tech_support:
       name: "Tech Support"
       description: "10 Accepted answers"
+
+  education:
+    topic_is_solved: |
+      ### This topic has been solved
+
+      Only reply here if:
+
+      - You have additional details
+
+      - The solution doesn't work for you
+
+      If you have an unrelated issue, please [start a new topic](%{base_url}/new-topic) instead.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,3 +23,5 @@ plugins:
     client: true
   notify_on_staff_accept_solved:
     default: false
+  disable_solved_education_message:
+    default: false

--- a/plugin.rb
+++ b/plugin.rb
@@ -612,4 +612,18 @@ SQL
 
     options[:refresh_stream] = true if old_category_allows != new_category_allows
   end
+
+  add_to_class(:composer_messages_finder, :check_topic_is_solved) do
+    return if !SiteSetting.solved_enabled || SiteSetting.disable_solved_education_message
+    return if !replying? || @topic.blank? || @topic.private_message?
+    return if @topic.custom_fields["accepted_answer_post_id"].blank?
+
+    {
+      id: 'solved_topic',
+      templateName: 'education',
+      wait_for_typing: false,
+      extraClass: 'education-message',
+      body: PrettyText.cook(I18n.t('education.topic_is_solved', base_url: Discourse.base_url))
+    }
+  end
 end

--- a/spec/components/composer_messages_finder_spec.rb
+++ b/spec/components/composer_messages_finder_spec.rb
@@ -1,0 +1,41 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'composer_messages_finder'
+
+describe ComposerMessagesFinder do
+  context '.check_topic_is_solved' do
+    fab!(:user)  { Fabricate(:user) }
+    fab!(:topic) { Fabricate(:topic) }
+    fab!(:post) { Fabricate(:post, topic: topic, user: Fabricate(:user)) }
+
+    before do
+      SiteSetting.disable_solved_education_message = false
+    end
+
+    it "does not show message without a topic id" do
+      expect(described_class.new(user, composer_action: 'createTopic').check_topic_is_solved).to be_blank
+      expect(described_class.new(user, composer_action: 'reply').check_topic_is_solved).to be_blank
+    end
+
+    context "a reply" do
+      it "does not show message if topic is not solved" do
+        expect(described_class.new(user, composer_action: 'reply', topic_id: topic.id).check_topic_is_solved).to be_blank
+      end
+
+      it "does not show message if disable_solved_education_message is true" do
+        SiteSetting.disable_solved_education_message = true
+        DiscourseSolved.accept_answer!(post, Discourse.system_user)
+        expect(described_class.new(user, composer_action: 'reply', topic_id: topic.id).check_topic_is_solved).to be_blank
+      end
+
+      it "shows message if the topic is solved" do
+        DiscourseSolved.accept_answer!(post, Discourse.system_user)
+        message = described_class.new(user, composer_action: 'reply', topic_id: topic.id).check_topic_is_solved
+        expect(message).not_to be_blank
+        expect(message[:body]).to include("This topic has been solved")
+      end
+    end
+  end
+end


### PR DESCRIPTION
When replying on solved topic users will now see this education message:

![Screenshot from 2021-06-12 23-22-27](https://user-images.githubusercontent.com/5732281/121785045-20946200-cbd5-11eb-8356-3ce742628c18.png)

This message can be disabled from site setting.

Meta reference: https://meta.discourse.org/t/rfe-for-solved-plugin-make-new-topic-more-obvious/177680/5?u=techapj