### PR TITLE
Two extra options

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -10,6 +10,7 @@ en:
     notify_on_staff_accept_solved: "Send notification to the topic creator when a post is marked as solution by a staff."
     disable_solved_education_message: "Disable education message for solved topics."
     accept_solutions_topic_starter: "Allow the topic starter to accept a solution."
+    solved_add_schema_markup: "When to add QAPage schema markup to HTML?"
   reports:
     accepted_solutions:
       title: "Accepted solutions"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -9,8 +9,8 @@ en:
     show_filter_by_solved_status: "Show a dropdown to filter a topic list by solved status."
     notify_on_staff_accept_solved: "Send notification to the topic creator when a post is marked as solution by a staff."
     disable_solved_education_message: "Disable education message for solved topics."
-    accept_solutions_topic_starter: "Allow the topic starter to accept a solution."
-    solved_add_schema_markup: "When to add QAPage schema markup to HTML?"
+    accept_solutions_topic_author: "Allow the topic author to accept a solution."
+    solved_add_schema_markup: "Add QAPage schema markup to HTML."
   reports:
     accepted_solutions:
       title: "Accepted solutions"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -9,6 +9,7 @@ en:
     show_filter_by_solved_status: "Show a dropdown to filter a topic list by solved status."
     notify_on_staff_accept_solved: "Send notification to the topic creator when a post is marked as solution by a staff."
     disable_solved_education_message: "Disable education message for solved topics."
+    accept_solutions_topic_starter: "Allow the topic starter to accept a solution."
   reports:
     accepted_solutions:
       title: "Accepted solutions"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -25,3 +25,5 @@ plugins:
     default: false
   disable_solved_education_message:
     default: false
+  accept_solutions_topic_starter:
+    default: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -25,7 +25,7 @@ plugins:
     default: false
   disable_solved_education_message:
     default: false
-  accept_solutions_topic_starter:
+  accept_solutions_topic_author:
     default: true
   solved_add_schema_markup:
     type: enum

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -27,3 +27,11 @@ plugins:
     default: false
   accept_solutions_topic_starter:
     default: true
+  solved_add_schema_markup:
+    type: enum
+    default: "always"
+    choices:
+      - "never"
+      - "always"
+      - "answered only"
+

--- a/plugin.rb
+++ b/plugin.rb
@@ -282,6 +282,7 @@ SQL
     # it can get confusing to have this on every page and it should make page 1
     # a bit more prominent + cut down on pointless work
 
+    return "" if SiteSetting.solved_add_schema_markup == "never"
     return "" if !controller.guardian.allow_accepted_answers_on_category?(topic.category_id)
 
     first_post = topic_view.posts&.first
@@ -313,6 +314,8 @@ SQL
           'name' => accepted_answer.user&.username
         }
       }
+    else
+      return "" if SiteSetting.solved_add_schema_markup == "answered only"
     end
 
     ['<script type="application/ld+json">', MultiJson.dump(

--- a/plugin.rb
+++ b/plugin.rb
@@ -483,7 +483,7 @@ SQL
         return true if can_perform_action_available_to_group_moderators?(topic)
       end
 
-      topic.user_id == current_user.id && !topic.closed
+      topic.user_id == current_user.id && !topic.closed && SiteSetting.accept_solutions_topic_starter
     end
   end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -486,7 +486,7 @@ SQL
         return true if can_perform_action_available_to_group_moderators?(topic)
       end
 
-      topic.user_id == current_user.id && !topic.closed && SiteSetting.accept_solutions_topic_starter
+      topic.user_id == current_user.id && !topic.closed && SiteSetting.accept_solutions_topic_author
     end
   end
 


### PR DESCRIPTION
We've added two options on behalf of a client and I think they might be useful for a broader audience.

- Optionally disallow topic starters to select a solution (leaving that to staff or high trust level users).
- Make inserting QAPage schema markup optional since that is not always desired.