### PR TITLE
FIX: Use preloaded custom fields on category

### DIFF
--- a/assets/javascripts/discourse/pre-initializers/extend-category-for-solved.js.es6
+++ b/assets/javascripts/discourse/pre-initializers/extend-category-for-solved.js.es6
@@ -11,7 +11,15 @@ export default {
         "custom_fields.enable_accepted_answers",
         {
           get(fieldName) {
-            return Ember.get(this.custom_fields, fieldName) === "true";
+            if (this.custom_fields) {
+              return Ember.get(this.custom_fields, fieldName) === "true";
+            } else if (this.preloaded_custom_fields) {
+              return (
+                Ember.get(this.preloaded_custom_fields, fieldName) === "true"
+              );
+            } else {
+              return false;
+            }
           },
         }
       ),


### PR DESCRIPTION
The 'show filter by solved status' codepath was not tested with the move to preloaded custom fields.