### PR TITLE
FIX: typo in mixin and incorrect setting description

### DIFF
--- a/app/serializers/concerns/topic_answer_mixin.rb
+++ b/app/serializers/concerns/topic_answer_mixin.rb
@@ -16,7 +16,7 @@ module TopicAnswerMixin
   def can_have_answer
     return true if SiteSetting.allow_solved_on_all_topics
     return false if object.closed || object.archived
-    scope.allow_accepted_answer?(object.category_id, object.tags.map(&:name))
+    scope.allow_accepted_answers?(object.category_id, object.tags.map(&:name))
   end
 
   def include_can_have_answer?

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3,7 +3,7 @@ en:
 
   site_settings:
     solved_enabled: "Enable solved plugin, allow users to select solutions for topics"
-    allow_solved_on_all_topics: "Allow users to select solutions on all topics (by default you control this by editing categories)"
+    allow_solved_on_all_topics: "Allow users to select solutions on all topics (when unchecked, solutions can be enabled per category or tag)"
     accept_all_solutions_trust_level: "Minimum trust level required to accept solutions on any topic (even when not OP)"
     empty_box_on_unsolved: "Display an empty box next to unsolved topics"
     solved_quote_length: "Number of characters to quote when displaying the solution under the first post"
@@ -13,7 +13,7 @@ en:
     disable_solved_education_message: "Disable education message for solved topics."
     accept_solutions_topic_author: "Allow the topic author to accept a solution."
     solved_add_schema_markup: "Add QAPage schema markup to HTML."
-    enable_solved_tags: "Allow users to select solutions on all topics (when unchecked, solutions can be enabled per category or tag)"
+    enable_solved_tags: "Tags that will allow users to select solutions."
 
   reports:
     accepted_solutions:


### PR DESCRIPTION
`allow_accepted_answer` should be `allow_accepted_answers` (with an `s` at the end) in the `TopicAnswerMixin`.

The `enable_solved_tags` setting description seemed to be using the description intended for `allow_solved_on_all_topics`. Both descriptions have been updated.