### PR TITLE
UX: prevent solution text and icon from wrapping

### DIFF
--- a/assets/stylesheets/solutions.scss
+++ b/assets/stylesheets/solutions.scss
@@ -26,6 +26,7 @@ $solved-color: green;
 .post-controls .extra-buttons {
   // anon text
   .accepted-text {
+    white-space: nowrap;
     .d-icon,
     .accepted-label {
       color: $solved-color;


### PR DESCRIPTION
Stops this from happening:
![Screen Shot 2021-12-14 at 8 59 19 PM](https://user-images.githubusercontent.com/1681963/146109134-327e85e6-d5d0-41f7-9d34-2b6027555eac.png)

