### PR TITLE
FIX: Add a noticeId to store state

### DIFF
--- a/assets/javascripts/discourse/connectors/topic-navigation/no-answer.hbs
+++ b/assets/javascripts/discourse/connectors/topic-navigation/no-answer.hbs
@@ -1,5 +1,5 @@
 {{#if show}}
-  {{#topic-navigation-popup}}
+  {{#topic-navigation-popup popupId="solved-notice" dismissDuration=oneWeek}}
     <h3>{{i18n "solved.no_answer.title"}}</h3>
     <p>{{i18n "solved.no_answer.description"}}</p>
   {{/topic-navigation-popup}}

--- a/assets/javascripts/discourse/connectors/topic-navigation/no-answer.js.es6
+++ b/assets/javascripts/discourse/connectors/topic-navigation/no-answer.js.es6
@@ -1,11 +1,15 @@
 import { later } from "@ember/runloop";
 
-// 7 days in milliseconds
-const MAX_DURATION_WITH_NO_ANSWER = 7 * 24 * 60 * 60 * 1000;
+const ONE_WEEK = 7 * 24 * 60 * 60 * 1000; // milliseconds
+const MAX_DURATION_WITH_NO_ANSWER = ONE_WEEK;
 
 export default {
   setupComponent(args, component) {
     component.set("show", false);
+    component.setProperties({
+      oneWeek: ONE_WEEK,
+      show: false,
+    });
 
     later(() => {
       if (


### PR DESCRIPTION
The dismissed state will be stored in local storage because noticeId is
present now.

Merge after https://github.com/discourse/discourse/pull/15570