### PR TITLE
DEV: Fix specs for personal_message_enabled_groups setting

### DIFF
--- a/spec/lib/first_accepted_post_solution_validator_spec.rb
+++ b/spec/lib/first_accepted_post_solution_validator_spec.rb
@@ -63,6 +63,7 @@ describe FirstAcceptedPostSolutionValidator do
 
   context 'when post is a PM' do
     it 'doesn’t validate the post' do
+      Group.refresh_automatic_groups!
       post_1 = create_post(user: user_tl1, target_usernames: [user_tl1.username], archetype: Archetype.private_message)
       expect(described_class.check(post_1, trust_level: 'any')).to eq(false)
     end


### PR DESCRIPTION
See https://github.com/discourse/discourse/pull/18437, we are removing any references to enable_personal_messages in core and using only personal_message_enabled_groups, which requires auto groups to be assigned in certain specs for them to keep working.