### PR TITLE
FIX: Add title to solved notifications

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -31,6 +31,8 @@ en:
       no_answer:
         title: Has your question been answered?
         description: "Highlight the answer and help others by using the solution button below the correct reply."
+      notification:
+        title: "your post was marked as solution"
 
     topic_statuses:
       solved:

--- a/plugin.rb
+++ b/plugin.rb
@@ -110,6 +110,7 @@ SQL
           message: "solved.accepted_notification",
           display_username: acting_user.username,
           topic_title: topic.title,
+          title: "solved.notification.title",
         }.to_json
 
         unless acting_user.id == post.user_id


### PR DESCRIPTION
This PR adds a title that appears when hovering over solved notifications in the UI.

Screenshot:

<img width=400 src="https://user-images.githubusercontent.com/17474474/218884545-aea4e122-7076-4a9d-9737-8820212a1210.png">
