### PR TITLE
UX: Tweak 'Solution' button design

### DIFF
--- a/assets/javascripts/discourse/initializers/extend-for-solved-button.js
+++ b/assets/javascripts/discourse/initializers/extend-for-solved-button.js
@@ -90,8 +90,6 @@ function initializeWithApi(api) {
     const canUnaccept = attrs.can_unaccept_answer;
     const accepted = attrs.accepted_answer;
     const isOp = currentUser && currentUser.id === attrs.topicCreatedById;
-    const position =
-      !accepted && canAccept && !isOp ? "second-last-hidden" : "first";
 
     if (canAccept) {
       return {
@@ -99,8 +97,8 @@ function initializeWithApi(api) {
         icon: "far-check-square",
         className: "unaccepted",
         title: "solved.accept_answer",
-        label: "solved.solution",
-        position,
+        label: isOp ? "solved.solution" : null,
+        position: isOp ? "first" : "second",
       };
     } else if (canUnaccept && accepted) {
       const title = canUnaccept
@@ -111,14 +109,14 @@ function initializeWithApi(api) {
         icon: "check-square",
         title,
         className: "accepted fade-out",
-        position,
-        label: "solved.solution",
+        position: isOp ? "first" : "second",
+        label: isOp ? "solved.solution" : null,
       };
     } else if (!canAccept && accepted) {
       return {
         className: "hidden",
         disabled: "true",
-        position,
+        position: "first",
         beforeButton(h) {
           return h(
             "span.accepted-text",


### PR DESCRIPTION
If user can accept / unaccept and is OP:

![image](https://user-images.githubusercontent.com/23153890/223826618-52a3fb49-5649-4ae9-9d2c-a19f06830587.png)

If user can accept / unaccept, but it is not OP:

![image](https://user-images.githubusercontent.com/23153890/223826637-76467497-ba2c-4f4c-9b46-4269ff88f6b6.png)

If user cannot accept / unaccept:

![image](https://user-images.githubusercontent.com/23153890/223826655-68281bd1-1e32-4534-952d-81b11083474d.png)

![image](https://user-images.githubusercontent.com/23153890/223826669-9626371f-2c6a-479d-a0b6-210d2502b96a.png)
