### PR TITLE
UX: Tweak 'Solution' button design

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -504,7 +504,7 @@ SQL
 
   require_dependency "post_serializer"
   class ::PostSerializer
-    attributes :can_accept_answer, :can_unaccept_answer, :accepted_answer
+    attributes :can_accept_answer, :can_unaccept_answer, :accepted_answer, :topic_accepted_answer
 
     def can_accept_answer
       if topic = (topic_view && topic_view.topic) || object.topic
@@ -523,6 +523,12 @@ SQL
 
     def accepted_answer
       post_custom_fields["is_accepted_answer"] == "true"
+    end
+
+    def topic_accepted_answer
+      if topic = (topic_view && topic_view.topic) || object.topic
+        topic.custom_fields["accepted_answer_post_id"].present?
+      end
     end
   end
 


### PR DESCRIPTION
Hide the accept solution button if a solution has been accepted already.

## Before

After accepting solution (the user is OP):

<img width="765" alt="image" src="https://user-images.githubusercontent.com/23153890/225608923-e1742c6e-4dbb-404b-bf72-e9385a02254a.png">

After accepting solution (the user is not OP):

<img width="778" alt="image" src="https://user-images.githubusercontent.com/23153890/225609043-24dd3b65-96d9-40e8-8bc9-cbb399741607.png">

## After

After accepting solution:

<img width="780" alt="image" src="https://user-images.githubusercontent.com/23153890/225607780-2c684a68-8cdb-41a4-8c03-945ed1747d18.png">
