### PR TITLE
FEATURE: prioritize_solved_topics_in_search to prioritize solved topics

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -14,6 +14,7 @@ en:
     accept_solutions_topic_author: "Allow the topic author to accept a solution."
     solved_add_schema_markup: "Add QAPage schema markup to HTML."
     enable_solved_tags: "Tags that will allow users to select solutions."
+    prioritize_solved_topics_in_search: "Prioritize solved topics in search results."
 
   reports:
     accepted_solutions:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -34,6 +34,7 @@ plugins:
       - "never"
       - "always"
       - "answered only"
+  prioritize_solved_topics_in_search: false
   enable_solved_tags:
     type: tag_list
     default: ""

--- a/plugin.rb
+++ b/plugin.rb
@@ -382,12 +382,12 @@ SQL
 
   if respond_to?(:register_modifier)
     register_modifier(:search_rank_sort_priorities) do |priorities, search|
-      if SiteSetting.prioritize_solved_topics_in_search 
+      if SiteSetting.prioritize_solved_topics_in_search
         condition = <<~SQL
           EXISTS
             (
               SELECT 1 FROM topic_custom_fields f
-              WHERE topics.id = f.topic_id 
+              WHERE topics.id = f.topic_id
               AND f.name = '#{::DiscourseSolved::ACCEPTED_ANSWER_POST_ID_CUSTOM_FIELD}'
             )
         SQL

--- a/plugin.rb
+++ b/plugin.rb
@@ -382,15 +382,20 @@ SQL
 
   if respond_to?(:register_modifier)
     register_modifier(:search_rank_sort_priorities) do |priorities, search|
-      priorities << [<<~SQL, 1.1] if SiteSetting.prioritize_solved_topics_in_search
-            EXISTS
-              (
-                SELECT 1 FROM topic_custom_fields f
-                WHERE topics.id = f.topic_id AND
-                  f.name = '#{::DiscourseSolved::ACCEPTED_ANSWER_POST_ID_CUSTOM_FIELD}'
-              )
-          SQL
-      priorities
+      if SiteSetting.prioritize_solved_topics_in_search 
+        condition = <<~SQL
+          EXISTS
+            (
+              SELECT 1 FROM topic_custom_fields f
+              WHERE topics.id = f.topic_id 
+              AND f.name = '#{::DiscourseSolved::ACCEPTED_ANSWER_POST_ID_CUSTOM_FIELD}'
+            )
+        SQL
+
+        priorities.push([condition, 1.1])
+      else
+        priorities
+      end
     end
   end
 

--- a/spec/integration/solved_spec.rb
+++ b/spec/integration/solved_spec.rb
@@ -15,8 +15,6 @@ RSpec.describe "Managing Posts solved status" do
     after { SearchIndexer.disable }
 
     it "can prioritize solved topics in search" do
-      SiteSetting.prioritize_solved_topics_in_search = true
-
       normal_post =
         Fabricate(
           :post,
@@ -32,6 +30,11 @@ RSpec.describe "Managing Posts solved status" do
         )
 
       DiscourseSolved.accept_answer!(solved_post, Discourse.system_user)
+
+      result = Search.execute("carrot")
+      expect(result.posts.pluck(:id)).to eq([normal_post.id, solved_post.id])
+
+      SiteSetting.prioritize_solved_topics_in_search = true
 
       result = Search.execute("carrot")
       expect(result.posts.pluck(:id)).to eq([solved_post.id, normal_post.id])


### PR DESCRIPTION
Many consumers of Discourse solve may want solved topics to show up more
prominently in search. New setting (default off) allows bumping these topics
to the top.
