### PR TITLE
FIX: Search bug for status:unsolved returns topics from non-solution enabled categories

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -588,7 +588,16 @@ SQL
     end
 
     Search.advanced_filter(/status:unsolved/) do |posts|
-      unless SiteSetting.allow_solved_on_all_topics
+      if SiteSetting.allow_solved_on_all_topics
+        posts.where(
+          "topics.id NOT IN (
+          SELECT tc.topic_id
+          FROM topic_custom_fields tc
+          WHERE tc.name = '#{::DiscourseSolved::ACCEPTED_ANSWER_POST_ID_CUSTOM_FIELD}' AND
+                          tc.value IS NOT NULL
+          )",
+        )
+      else
         posts.where(
           "topics.id NOT IN (
           SELECT tc.topic_id
@@ -602,15 +611,6 @@ SQL
             ON top.category_id = cc.category_id
             WHERE cc.name = '#{::DiscourseSolved::ENABLE_ACCEPTED_ANSWERS_CUSTOM_FIELD}' AND
                           cc.value = 'true'
-          )",
-        )
-      else
-        posts.where(
-          "topics.id NOT IN (
-          SELECT tc.topic_id
-          FROM topic_custom_fields tc
-          WHERE tc.name = '#{::DiscourseSolved::ACCEPTED_ANSWER_POST_ID_CUSTOM_FIELD}' AND
-                          tc.value IS NOT NULL
           )",
         )
       end

--- a/plugin.rb
+++ b/plugin.rb
@@ -76,6 +76,7 @@ SQL
 
     AUTO_CLOSE_TOPIC_TIMER_CUSTOM_FIELD = "solved_auto_close_topic_timer_id"
     ACCEPTED_ANSWER_POST_ID_CUSTOM_FIELD = "accepted_answer_post_id"
+    ENABLE_ACCEPTED_ANSWERS_CUSTOM_FIELD = "enable_accepted_answers"
 
     def self.accept_answer!(post, acting_user, topic: nil)
       topic ||= post.topic
@@ -502,9 +503,10 @@ SQL
     def self.reset_accepted_answer_cache
       @@allowed_accepted_cache["allowed"] = begin
         Set.new(
-          CategoryCustomField.where(name: "enable_accepted_answers", value: "true").pluck(
-            :category_id,
-          ),
+          CategoryCustomField.where(
+            name: ::DiscourseSolved::ENABLE_ACCEPTED_ANSWERS_CUSTOM_FIELD,
+            value: "true",
+          ).pluck(:category_id),
         )
       end
     end
@@ -586,14 +588,32 @@ SQL
     end
 
     Search.advanced_filter(/status:unsolved/) do |posts|
-      posts.where(
-        "topics.id NOT IN (
-        SELECT tc.topic_id
-        FROM topic_custom_fields tc
-        WHERE tc.name = '#{::DiscourseSolved::ACCEPTED_ANSWER_POST_ID_CUSTOM_FIELD}' AND
-                        tc.value IS NOT NULL
-        )",
-      )
+      unless SiteSetting.allow_solved_on_all_topics
+        posts.where(
+          "topics.id NOT IN (
+          SELECT tc.topic_id
+          FROM topic_custom_fields tc
+          WHERE tc.name = '#{::DiscourseSolved::ACCEPTED_ANSWER_POST_ID_CUSTOM_FIELD}' AND
+                          tc.value IS NOT NULL
+          ) AND topics.id IN (
+            SELECT top.id 
+            FROM topics top
+            INNER JOIN category_custom_fields cc
+            ON top.category_id = cc.category_id
+            WHERE cc.name = '#{::DiscourseSolved::ENABLE_ACCEPTED_ANSWERS_CUSTOM_FIELD}' AND
+                          cc.value = 'true'
+          )",
+        )
+      else
+        posts.where(
+          "topics.id NOT IN (
+          SELECT tc.topic_id
+          FROM topic_custom_fields tc
+          WHERE tc.name = '#{::DiscourseSolved::ACCEPTED_ANSWER_POST_ID_CUSTOM_FIELD}' AND
+                          tc.value IS NOT NULL
+          )",
+        )
+      end
     end
   end
 
@@ -655,7 +675,7 @@ SQL
     TopicList.preloaded_custom_fields << ::DiscourseSolved::ACCEPTED_ANSWER_POST_ID_CUSTOM_FIELD
   end
   if Site.respond_to? :preloaded_category_custom_fields
-    Site.preloaded_category_custom_fields << "enable_accepted_answers"
+    Site.preloaded_category_custom_fields << ::DiscourseSolved::ENABLE_ACCEPTED_ANSWERS_CUSTOM_FIELD
   end
   if Search.respond_to? :preloaded_topic_custom_fields
     Search.preloaded_topic_custom_fields << ::DiscourseSolved::ACCEPTED_ANSWER_POST_ID_CUSTOM_FIELD
@@ -696,7 +716,7 @@ SQL
         )
       CategoryCustomField.create!(
         category_id: solved_category.id,
-        name: "enable_accepted_answers",
+        name: ::DiscourseSolved::ENABLE_ACCEPTED_ANSWERS_CUSTOM_FIELD,
         value: "true",
       )
       puts "discourse-solved enabled on category '#{solved_category.name}' (#{solved_category.id})."
@@ -706,7 +726,7 @@ SQL
       unless SiteSetting.allow_solved_on_all_topics
         solved_category_id =
           CategoryCustomField
-            .where(name: "enable_accepted_answers", value: "true")
+            .where(name: ::DiscourseSolved::ENABLE_ACCEPTED_ANSWERS_CUSTOM_FIELD, value: "true")
             .first
             .category_id
 

--- a/spec/fabricators/extend_topic_fabricator.rb
+++ b/spec/fabricators/extend_topic_fabricator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Fabricator(:custom_topic, from: :topic) do
   transient :custom_topic_name
   transient :value

--- a/spec/fabricators/extend_topic_fabricator.rb
+++ b/spec/fabricators/extend_topic_fabricator.rb
@@ -1,0 +1,13 @@
+Fabricator(:custom_topic, from: :topic) do
+  transient :custom_topic_name
+  transient :value
+  after_create do |top, transients|
+    custom_topic =
+      TopicCustomField.new(
+        topic_id: top.id,
+        name: transients[:custom_topic_name],
+        value: transients[:value],
+      )
+    custom_topic.save
+  end
+end


### PR DESCRIPTION
**Context** 
Advanced search using `status:unsolved` is supposed to return all topics/posts that have the `solved` plugin enabled and have a status of unsolved.

**Problem**
Advanced search using `status:unsolved` is also returning results from topics/posts that don't have the `solved` plugin enabled.

**Solution**
Fix the SQL query for `status:unsolved` to ignore topics/posts that also have `custom_topic_fields` and only search for those that belong to a category where the plugin is enabled. 