### PR TITLE
FIX: do not show solved/unsolved filter when editing category

### DIFF
--- a/assets/javascripts/discourse/connectors/bread-crumbs-right/solved-status-filter.js
+++ b/assets/javascripts/discourse/connectors/bread-crumbs-right/solved-status-filter.js
@@ -21,7 +21,8 @@ export default class SolvedStatusFilter extends Component {
 
     if (
       !helper.siteSettings.show_filter_by_solved_status ||
-      router.currentRouteName === "discovery.categories"
+      router.currentRouteName === "discovery.categories" ||
+      args.editingCategory
     ) {
       return false;
     } else if (helper.siteSettings.allow_solved_on_all_topics) {

--- a/assets/stylesheets/solutions.scss
+++ b/assets/stylesheets/solutions.scss
@@ -3,6 +3,7 @@ $solved-color: green;
 .select-kit {
   &.solved-status-filter {
     min-width: auto;
+    margin-right: 0.5em;
     .select-kit-header {
       margin: 0;
     }


### PR DESCRIPTION
FIX: do not show solved/unsolved filter when editing category

Before:

<img width="290" alt="Screenshot 2023-09-26 at 6 28 15 PM" src="https://github.com/discourse/discourse-solved/assets/11170663/3f7fbccf-019d-4900-b15c-416ac6c163e3">

After:

<img width="349" alt="Screenshot 2023-09-26 at 6 28 00 PM" src="https://github.com/discourse/discourse-solved/assets/11170663/5d8bac35-a825-460e-a120-86a84124ecdd">


UX: add spacing for solved/unsolved filter dropdown

Before:

<img width="397" alt="Screenshot 2023-09-26 at 6 18 27 PM" src="https://github.com/discourse/discourse-solved/assets/11170663/bbc3c4bb-4823-468c-908e-f1f48479b3fd">

After:

<img width="407" alt="Screenshot 2023-09-26 at 6 18 37 PM" src="https://github.com/discourse/discourse-solved/assets/11170663/55479350-d068-4dbb-b4e3-ccd99c8fd378">
