### PR TITLE
FIX: Correct getOwner import

### DIFF
--- a/assets/javascripts/discourse/connectors/bread-crumbs-right/solved-status-filter.js
+++ b/assets/javascripts/discourse/connectors/bread-crumbs-right/solved-status-filter.js
@@ -1,5 +1,5 @@
 import I18n from "I18n";
-import { getOwner } from "@ember/application";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
@@ -17,7 +17,7 @@ const UX_VALUES = {
 
 export default class SolvedStatusFilter extends Component {
   static shouldRender(args, helper) {
-    const router = getOwner(this).lookup("service:router");
+    const router = getOwnerWithFallback(this).lookup("service:router");
 
     if (
       !helper.siteSettings.show_filter_by_solved_status ||


### PR DESCRIPTION
As it's currently implemented, the fallback is essential here. `this` in a static method is `undefined`, and therefore cannot have an owner.

Unfortunately this plugin outlet does not seem to be tested in the plugin's own test suite. Core's test suite picked up this issue.

Followup to 3a0b46da7aa48e27e51c74e90b42c2083d89b4d5