### PR TITLE
UX: add `linked-stat` class to profile stat

### DIFF
--- a/assets/javascripts/discourse/connectors/user-summary-stat/solved-count.hbs
+++ b/assets/javascripts/discourse/connectors/user-summary-stat/solved-count.hbs
@@ -1,5 +1,5 @@
 {{#if (and this.siteSettings.solved_enabled @outletArgs.model.solved_count)}}
-  <li class="user-summary-stat-outlet solved-count">
+  <li class="user-summary-stat-outlet solved-count linked-stat">
     <LinkTo @route="userActivity.solved">
       <UserStat
         @value={{@outletArgs.model.solved_count}}


### PR DESCRIPTION
Adds a missing class to apply styling to the user profile solved stat

Before:
![Screenshot 2023-11-06 at 1 17 19 PM](https://github.com/discourse/discourse-solved/assets/1681963/03f06598-8de0-48f0-91d8-8ee109c687b2)

After:
![Screenshot 2023-11-06 at 1 17 05 PM](https://github.com/discourse/discourse-solved/assets/1681963/92378c67-f517-43f8-a622-9e80fb8a2939)
