### PR TITLE
DEV: Replace deprecated min_trust_to_create_post

### DIFF
--- a/spec/lib/first_accepted_post_solution_validator_spec.rb
+++ b/spec/lib/first_accepted_post_solution_validator_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe FirstAcceptedPostSolutionValidator do
-  fab!(:user_tl1) { Fabricate(:user, trust_level: TrustLevel[1]) }
+  fab!(:user_tl1) { Fabricate(:user, trust_level: TrustLevel[1], refresh_auto_groups: true) }
 
   context "when user is under max trust level" do
     context "with no post accepted yet" do


### PR DESCRIPTION
In https://github.com/discourse/discourse/pull/24740, `min_trust_to_create_topic` site setting was replaced by `create_topic_allowed_groups`. This PR replaces the former, deprecated one, with the latter.