### PR TITLE
FEATURE: change status on unsolve & fix assign changes

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -13,6 +13,7 @@ en:
     notify_on_staff_accept_solved: "Send notification to the topic creator when a post is marked as solution by a staff."
     ignore_solved_topics_in_assigned_reminder: "Prevent assigned reminder from including solved topics. only relevant when discourse-assign."
     assignment_status_on_solve: "When a topic is solved update all assignments to this status"
+    assignment_status_on_unsolve: "When a topic is unsolved update all assignments to this status"
     disable_solved_education_message: "Disable education message for solved topics."
     accept_solutions_topic_author: "Allow the topic author to accept a solution."
     solved_add_schema_markup: "Add QAPage schema markup to HTML."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -37,6 +37,9 @@ discourse_solved:
   assignment_status_on_solve:
     type: string
     default: ""
+  assignment_status_on_unsolve:
+    type: string
+    default: ""
   disable_solved_education_message:
     default: false
   accept_solutions_topic_author:

--- a/plugin.rb
+++ b/plugin.rb
@@ -591,19 +591,47 @@ after_initialize do
   if defined?(DiscourseAssign)
     on(:accepted_solution) do |post|
       next if SiteSetting.assignment_status_on_solve.blank?
-      assigned_user = User.find_by(id: post.topic.assignment.assigned_to_id)
-      Assigner.new(post.topic, assigned_user).assign(
-        assigned_user,
-        status: SiteSetting.assignment_status_on_solve,
-      )
+      assignements = Assignment.where(topic: post.topic)
+      assignements.each do |assignment|
+        assigned_user = User.find_by(id: assignment.assigned_to_id)
+        target_id = assignment.target_id
+
+        target =
+          case assignment.target_type
+          when "Post"
+            Post.find_by(id: target_id)
+          when "Topic"
+            Topic.find_by(id: target_id)
+          else
+            post.topic
+          end
+
+        Assigner.new(target, assigned_user).assign(
+          assigned_user,
+          status: SiteSetting.assignment_status_on_solve,
+        )
+      end
     end
     on(:unaccepted_solution) do |post|
       next if SiteSetting.assignment_status_on_unsolve.blank?
-      assigned_user = User.find_by(id: post.topic.assignment.assigned_to_id)
-      Assigner.new(post.topic, assigned_user).assign(
-        assigned_user,
-        status: SiteSetting.assignment_status_on_unsolve,
-      )
+      assignements = Assignment.where(topic: post.topic)
+      assignements.each do |assignment|
+        assigned_user = User.find_by(id: assignment.assigned_to_id)
+        target_id = assignment.target_id
+        target =
+          case assignment.target_type
+          when "Post"
+            Post.find_by(id: target_id)
+          when "Topic"
+            Topic.find_by(id: target_id)
+          else
+            post.topic
+          end
+        Assigner.new(target, assigned_user).assign(
+          assigned_user,
+          status: SiteSetting.assignment_status_on_unsolve,
+        )
+      end
     end
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -591,22 +591,10 @@ after_initialize do
   if defined?(DiscourseAssign)
     on(:accepted_solution) do |post|
       next if SiteSetting.assignment_status_on_solve.blank?
-      assignements = Assignment.where(topic: post.topic)
-      assignements.each do |assignment|
+      assignments = Assignment.includes(:target).where(topic: post.topic)
+      assignments.each do |assignment|
         assigned_user = User.find_by(id: assignment.assigned_to_id)
-        target_id = assignment.target_id
-
-        target =
-          case assignment.target_type
-          when "Post"
-            Post.find_by(id: target_id)
-          when "Topic"
-            Topic.find_by(id: target_id)
-          else
-            post.topic
-          end
-
-        Assigner.new(target, assigned_user).assign(
+        Assigner.new(assignment.target, assigned_user).assign(
           assigned_user,
           status: SiteSetting.assignment_status_on_solve,
         )
@@ -614,20 +602,10 @@ after_initialize do
     end
     on(:unaccepted_solution) do |post|
       next if SiteSetting.assignment_status_on_unsolve.blank?
-      assignements = Assignment.where(topic: post.topic)
-      assignements.each do |assignment|
+      assignments = Assignment.includes(:target).where(topic: post.topic)
+      assignments.each do |assignment|
         assigned_user = User.find_by(id: assignment.assigned_to_id)
-        target_id = assignment.target_id
-        target =
-          case assignment.target_type
-          when "Post"
-            Post.find_by(id: target_id)
-          when "Topic"
-            Topic.find_by(id: target_id)
-          else
-            post.topic
-          end
-        Assigner.new(target, assigned_user).assign(
+        Assigner.new(assignment.target, assigned_user).assign(
           assigned_user,
           status: SiteSetting.assignment_status_on_unsolve,
         )

--- a/plugin.rb
+++ b/plugin.rb
@@ -303,7 +303,7 @@ after_initialize do
     if SiteSetting.prioritize_solved_topics_in_search
       condition = <<~SQL
           EXISTS (
-            SELECT 1 
+            SELECT 1
               FROM topic_custom_fields
              WHERE topic_id = topics.id
                AND name = '#{::DiscourseSolved::ACCEPTED_ANSWER_POST_ID_CUSTOM_FIELD}'
@@ -336,7 +336,7 @@ after_initialize do
       topics.id IN (
         SELECT topic_id
           FROM topic_custom_fields
-         WHERE name = '#{::DiscourseSolved::ACCEPTED_ANSWER_POST_ID_CUSTOM_FIELD}' 
+         WHERE name = '#{::DiscourseSolved::ACCEPTED_ANSWER_POST_ID_CUSTOM_FIELD}'
            AND value IS NOT NULL
       )
     SQL
@@ -349,7 +349,7 @@ after_initialize do
       topics.id NOT IN (
         SELECT topic_id
           FROM topic_custom_fields
-         WHERE name = '#{::DiscourseSolved::ACCEPTED_ANSWER_POST_ID_CUSTOM_FIELD}' 
+         WHERE name = '#{::DiscourseSolved::ACCEPTED_ANSWER_POST_ID_CUSTOM_FIELD}'
            AND value IS NOT NULL
       )
     SQL
@@ -361,15 +361,15 @@ after_initialize do
         topics.id IN (
           SELECT t.id
             FROM topics t
-            JOIN category_custom_fields cc 
+            JOIN category_custom_fields cc
               ON t.category_id = cc.category_id
-             AND cc.name = '#{::DiscourseSolved::ENABLE_ACCEPTED_ANSWERS_CUSTOM_FIELD}' 
+             AND cc.name = '#{::DiscourseSolved::ENABLE_ACCEPTED_ANSWERS_CUSTOM_FIELD}'
              AND cc.value = 'true'
-        ) 
-        OR 
+        )
+        OR
         topics.id IN (
-          SELECT topic_id 
-            FROM topic_tags 
+          SELECT topic_id
+            FROM topic_tags
            WHERE tag_id IN (?)
         )
       SQL
@@ -404,7 +404,7 @@ after_initialize do
       ->(r) do
         sql = <<~SQL
           NOT EXISTS (
-            SELECT 1 
+            SELECT 1
               FROM topic_custom_fields
              WHERE topic_id = topics.id
                AND name = '#{::DiscourseSolved::ACCEPTED_ANSWER_POST_ID_CUSTOM_FIELD}'
@@ -591,9 +591,18 @@ after_initialize do
   if defined?(DiscourseAssign)
     on(:accepted_solution) do |post|
       next if SiteSetting.assignment_status_on_solve.blank?
-      Assigner.new(post.topic, post.acting_user).assign(
-        post.acting_user,
+      assigned_user = User.find_by(id: post.topic.assignment.assigned_to_id)
+      Assigner.new(post.topic, assigned_user).assign(
+        assigned_user,
         status: SiteSetting.assignment_status_on_solve,
+      )
+    end
+    on(:unaccepted_solution) do |post|
+      next if SiteSetting.assignment_status_on_unsolve.blank?
+      assigned_user = User.find_by(id: post.topic.assignment.assigned_to_id)
+      Assigner.new(post.topic, assigned_user).assign(
+        assigned_user,
+        status: SiteSetting.assignment_status_on_unsolve,
       )
     end
   end

--- a/spec/integration/solved_spec.rb
+++ b/spec/integration/solved_spec.rb
@@ -475,36 +475,30 @@ RSpec.describe "Managing Posts solved status" do
       end
 
       it "does not update the assignee when a post is accepted" do
-        # Bill asks a question.
-        # Roy responds and assigns to himself.
-        # Jojo responds with an answer.
-        # Bill thanks Jojo and marks her response as the solution.
-        # topic should still be assigneed to Roy
+        user_1 = Fabricate(:user)
+        user_2 = Fabricate(:user)
+        user_3 = Fabricate(:user)
+        group.add(user_1)
+        group.add(user_2)
+        group.add(user_3)
 
-        bill = Fabricate(:user)
-        roy = Fabricate(:user)
-        jojo = Fabricate(:user)
-        group.add(roy)
-        group.add(jojo)
-        group.add(bill)
+        topic_question = Fabricate(:topic, user: user_1)
+        post_question = Fabricate(:post, topic: topic_question, user: user_1)
 
-        topic_question = Fabricate(:topic, user: bill) # Bill asks a question.
-        post_question = Fabricate(:post, topic: topic_question, user: bill)
-
-        roy_response = Fabricate(:post, topic: topic_question, user: roy) # Roy responds...
-        assigner = Assigner.new(topic_question, roy)
-        result = assigner.assign(roy) # ...and assigns to himself.
+        user_2_response = Fabricate(:post, topic: topic_question, user: user_2)
+        assigner = Assigner.new(topic_question, user_2)
+        result = assigner.assign(user_2)
         expect(result[:success]).to eq(true)
 
-        post_response = Fabricate(:post, topic: topic_question, user: jojo) # Jojo responds with an answer.
+        post_response = Fabricate(:post, topic: topic_question, user: user_3)
 
-        DiscourseSolved.accept_answer!(post_response, bill) # Bill thanks Jojo and marks her response as the solution.
+        DiscourseSolved.accept_answer!(post_response, user_1)
 
-        expect(topic_question.assignment.assigned_to_id).to eq(roy.id) # topic should still be assigneed to Roy
+        expect(topic_question.assignment.assigned_to_id).to eq(user_2.id)
 
-        DiscourseSolved.unaccept_answer!(post_response) # Unaccept the answer
+        DiscourseSolved.unaccept_answer!(post_response)
 
-        expect(topic_question.assignment.assigned_to_id).to eq(roy.id) # topic should still be assigneed to Roy
+        expect(topic_question.assignment.assigned_to_id).to eq(user_2.id)
       end
 
       describe "assigned topic reminder"

--- a/spec/integration/solved_spec.rb
+++ b/spec/integration/solved_spec.rb
@@ -466,7 +466,7 @@ RSpec.describe "Managing Posts solved status" do
 
         DiscourseSolved.accept_answer!(p1, user)
 
-        expect(p1.topic.assignment.status).to eq("Done")
+        expect(p1.reload.topic.assignment.reload.status).to eq("Done")
 
         DiscourseSolved.unaccept_answer!(p1)
 
@@ -491,14 +491,16 @@ RSpec.describe "Managing Posts solved status" do
         expect(result[:success]).to eq(true)
 
         post_response = Fabricate(:post, topic: topic_question, user: user_3)
+        Assigner.new(post_response, user_3).assign(user_3)
 
         DiscourseSolved.accept_answer!(post_response, user_1)
 
         expect(topic_question.assignment.assigned_to_id).to eq(user_2.id)
-
+        expect(post_response.assignment.assigned_to_id).to eq(user_3.id)
         DiscourseSolved.unaccept_answer!(post_response)
 
         expect(topic_question.assignment.assigned_to_id).to eq(user_2.id)
+        expect(post_response.assignment.assigned_to_id).to eq(user_3.id)
       end
 
       describe "assigned topic reminder"


### PR DESCRIPTION
When a topic is unsolved, it should have an option, defined in the settings, to change its status to that state.

Fix assign changes when a topic was solved; previously, it changed the assignee.