### PR TITLE
UX: Add admins and moderators to `mandatory_values` for `accept_all_solutions_allowed_groups`

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,6 +12,7 @@ discourse_solved:
     hidden: true
   accept_all_solutions_allowed_groups:
     default: "14" # auto group trust_level_4
+    mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     client: false
     allow_any: false


### PR DESCRIPTION
This PR adds the `admins` and `moderators` automatic groups to the `mandatory_values` field of 
the `accept_all_solutions_allowed_groups` setting so that they're always shown in setting:

![image](https://github.com/discourse/discourse-solved/assets/17474474/4469a293-248b-4395-9b17-870ce0339a56)

We're doing this because admins and moderators can always accept a solution and it's not possible to remove the permission for them.

Internal topic: t/128143.