### PR TITLE
FIX: when deleting users with solved posts

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -137,6 +137,9 @@ after_initialize do
 
     def self.unaccept_answer!(post, topic: nil)
       topic ||= post.topic
+      topic ||= Topic.unscoped.find_by(id: post.topic_id)
+
+      return if topic.nil?
 
       DistributedMutex.synchronize("discourse_solved_toggle_answer_#{topic.id}") do
         post.custom_fields.delete(IS_ACCEPTED_ANSWER_CUSTOM_FIELD)


### PR DESCRIPTION
it would raise an error because we delete the topic before and we need the topic record to update various meta data.

This ensures we load the "deleted" version in such cases.

Internal ref - t/130797