### PR TITLE
A11Y: remove heading tag from usercard stat

### DIFF
--- a/assets/javascripts/discourse/connectors/user-card-metadata/accepted-answers.hbs
+++ b/assets/javascripts/discourse/connectors/user-card-metadata/accepted-answers.hbs
@@ -1,6 +1,4 @@
 {{#if user.accepted_answers}}
-  <h3>
-    <span class="desc">{{i18n "solutions"}}</span>
-    {{user.accepted_answers}}
-  </h3>
+  <span class="desc">{{i18n "solutions"}}</span>
+  <span>{{user.accepted_answers}}</span>
 {{/if}}


### PR DESCRIPTION
in https://github.com/discourse/discourse/commit/d4ade75583c2c5ef51b09b1d154c305719bc8788 heading tags were removed from the usercard 

this also removes them from the accepted answer stat that the solved plugin adds to the usercard so it's formatted consistently 