### PR TITLE
FIX: Don't allow TL4 users to unconditionally accept solutions

### DIFF
--- a/app/lib/guardian_extensions.rb
+++ b/app/lib/guardian_extensions.rb
@@ -28,7 +28,7 @@ module DiscourseSolved
       if current_user.in_any_groups?(SiteSetting.accept_all_solutions_allowed_groups_map)
         return true
       end
-      return true if can_perform_action_available_to_group_moderators?(topic)
+      return true if is_category_group_moderator?(topic.category)
 
       topic.user_id == current_user.id && !topic.closed && SiteSetting.accept_solutions_topic_author
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,7 +11,7 @@ discourse_solved:
     enum: "TrustLevelSetting"
     hidden: true
   accept_all_solutions_allowed_groups:
-    default: "14" # auto group trust_level_4
+    default: "1|2|14" # auto group admin, moderators and trust_level_4
     mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     client: false

--- a/spec/lib/guardian_extensions_spec.rb
+++ b/spec/lib/guardian_extensions_spec.rb
@@ -57,5 +57,11 @@ describe DiscourseSolved::GuardianExtensions do
       topic.update!(user: user)
       expect(guardian.can_accept_answer?(topic, post)).to eq(true)
     end
+
+    it "returns false if the user is trust level 4 but the trust level 4 group is not allowd to accept solutions" do
+      SiteSetting.accept_all_solutions_allowed_groups = Fabricate(:group).id
+      user.update!(trust_level: TrustLevel[4])
+      expect(guardian.can_accept_answer?(topic, post)).to eq(false)
+    end
   end
 end


### PR DESCRIPTION
A while ago the `accept_all_solutions_allowed_groups` setting was introduced to replace the `accept_all_solutions_trust_level` setting and to make the plugin more flexible by allowing admins to choose groups that are allowed to accept solutions instead of trust levels.

The new group-based setting includes the TL4 group by default. However, removing the TL4 group from the setting doesn't actually remove TL4 users permission to accept solution.

The reason for this bug is that the `can_accept_answer?` guardian method calls `can_perform_action_available_to_group_moderators?` which always allows TL4 users to perform category moderator actions:

https://github.com/discourse/discourse/blob/56524f4bdf9d45eddf7967ccead169ec6dd6cbb8/lib/guardian/topic_guardian.rb#L342-L348

This PR fixes the bug by checking if the user is a moderator on the topic's category (by calling the `is_category_group_moderator?` guardian method) instead of checking if the user can perform category moderator actions. In our case, `is_category_group_moderator?` is equivalent to `can_perform_action_available_to_group_moderators?` except for the TL4 check which is what we need.

Internal topic: t/134675.