### PR TITLE
DEV: Display unsolved icon only on the topic list

### DIFF
--- a/assets/javascripts/discourse/connectors/after-topic-status/solved-status.gjs
+++ b/assets/javascripts/discourse/connectors/after-topic-status/solved-status.gjs
@@ -1,27 +1,24 @@
-import Component from "@glimmer/component";
-import { service } from "@ember/service";
-import { or } from "truth-helpers";
+import { and, eq, or } from "truth-helpers";
 import icon from "discourse/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
-export default class SolvedStatus extends Component {
-  @service siteSettings;
-
-  <template>
-    {{~#if
-      (or
-        @outletArgs.topic.has_accepted_answer @outletArgs.topic.accepted_answer
-      )
-    ~}}
-      <span
-        title={{i18n "topic_statuses.solved.help"}}
-        class="topic-status"
-      >{{icon "far-square-check"}}</span>
-    {{~else if @outletArgs.topic.can_have_answer~}}
-      <span
-        title={{i18n "solved.has_no_accepted_answer"}}
-        class="topic-status"
-      >{{icon "far-square"}}</span>
-    {{~/if~}}
-  </template>
-}
+const SolvedStatus = <template>
+  {{~#if
+    (or @outletArgs.topic.has_accepted_answer @outletArgs.topic.accepted_answer)
+  ~}}
+    <span
+      title={{i18n "topic_statuses.solved.help"}}
+      class="topic-status"
+    >{{icon "far-square-check"}}</span>
+  {{~else if
+    (and
+      @outletArgs.topic.can_have_answer (eq @outletArgs.context "topic-list")
+    )
+  ~}}
+    <span
+      title={{i18n "solved.has_no_accepted_answer"}}
+      class="topic-status"
+    >{{icon "far-square"}}</span>
+  {{~/if~}}
+</template>;
+export default SolvedStatus;


### PR DESCRIPTION
…in the new topic-status implementation (using the next `@context` from https://github.com/discourse/discourse/pull/30940)

This roughly matches the old implementation (but there it was displayed in some places but not in others mostly because of implementation details/bugs)