### PR TITLE
FIX: don't allow or count solutions in PMs

### DIFF
--- a/app/lib/guardian_extensions.rb
+++ b/app/lib/guardian_extensions.rb
@@ -21,7 +21,7 @@ module DiscourseSolved
 
     def can_accept_answer?(topic, post)
       return false if !authenticated?
-      return false if !topic || topic.private_message? || !post || post.whisper? 
+      return false if !topic || topic.private_message? || !post || post.whisper?
       return false if !allow_accepted_answers?(topic.category_id, topic.tags.map(&:name))
 
       return true if is_staff?

--- a/app/lib/guardian_extensions.rb
+++ b/app/lib/guardian_extensions.rb
@@ -21,7 +21,7 @@ module DiscourseSolved
 
     def can_accept_answer?(topic, post)
       return false if !authenticated?
-      return false if !topic || !post || post.whisper?
+      return false if !topic || topic.private_message? || !post || post.whisper? 
       return false if !allow_accepted_answers?(topic.category_id, topic.tags.map(&:name))
 
       return true if is_staff?

--- a/plugin.rb
+++ b/plugin.rb
@@ -281,11 +281,12 @@ after_initialize do
     if category_id
       if include_subcategories
         accepted_solutions =
-          accepted_solutions
-            .where("topics.category_id IN (?)", Category.subcategory_ids(category_id))
+          accepted_solutions.where(
+            "topics.category_id IN (?)",
+            Category.subcategory_ids(category_id),
+          )
       else
-        accepted_solutions =
-          accepted_solutions.where("topics.category_id = ?", category_id)
+        accepted_solutions = accepted_solutions.where("topics.category_id = ?", category_id)
       end
     end
 
@@ -400,9 +401,7 @@ after_initialize do
   end
 
   register_modifier(:user_action_stream_builder) do |builder|
-    builder
-      .where("t.deleted_at IS NULL")
-      .where("t.archetype <> ?", Archetype.private_message)
+    builder.where("t.deleted_at IS NULL").where("t.archetype <> ?", Archetype.private_message)
   end
 
   TopicList.preloaded_custom_fields << ::DiscourseSolved::ACCEPTED_ANSWER_POST_ID_CUSTOM_FIELD

--- a/spec/integration/solved_spec.rb
+++ b/spec/integration/solved_spec.rb
@@ -601,13 +601,11 @@ RSpec.describe "Managing Posts solved status" do
       t2.convert_to_private_message(Discourse.system_user)
 
       expect(
-        UserAction
-          .stream(
-            user_id: user.id,
-            action_types: [::UserAction::SOLVED],
-            guardian: user.guardian
-          )
-          .map(&:post_id)
+        UserAction.stream(
+          user_id: user.id,
+          action_types: [::UserAction::SOLVED],
+          guardian: user.guardian,
+        ).map(&:post_id),
       ).to contain_exactly p3.id
     end
   end

--- a/spec/integration/solved_spec.rb
+++ b/spec/integration/solved_spec.rb
@@ -47,6 +47,16 @@ RSpec.describe "Managing Posts solved status" do
       )
     end
 
+    fab!(:solved_pm) do
+      Fabricate(
+        :custom_topic,
+        category_id: nil,
+        archetype: Archetype.private_message,
+        custom_topic_name: ::DiscourseSolved::ACCEPTED_ANSWER_POST_ID_CUSTOM_FIELD,
+        value: "42",
+      )
+    end
+
     fab!(:unsolved_in_category) { Fabricate(:topic, category: solvable_category) }
     fab!(:unsolved_in_tag) { Fabricate(:topic, tags: [solvable_tag]) }
 
@@ -570,6 +580,35 @@ RSpec.describe "Managing Posts solved status" do
       expect(reply.topic).to eq(nil)
 
       expect { DiscourseSolved.unaccept_answer!(reply) }.not_to raise_error
+    end
+  end
+
+  describe "user actions stream modifier" do
+    it "correctly list solutions" do
+      t1 = Fabricate(:topic)
+      t2 = Fabricate(:topic)
+      t3 = Fabricate(:topic)
+
+      p1 = Fabricate(:post, topic: t1, user:)
+      p2 = Fabricate(:post, topic: t2, user:)
+      p3 = Fabricate(:post, topic: t3, user:)
+
+      DiscourseSolved.accept_answer!(p1, Discourse.system_user)
+      DiscourseSolved.accept_answer!(p2, Discourse.system_user)
+      DiscourseSolved.accept_answer!(p3, Discourse.system_user)
+
+      t1.trash!(Discourse.system_user)
+      t2.convert_to_private_message(Discourse.system_user)
+
+      expect(
+        UserAction
+          .stream(
+            user_id: user.id,
+            action_types: [::UserAction::SOLVED],
+            guardian: user.guardian
+          )
+          .map(&:post_id)
+      ).to contain_exactly p3.id
     end
   end
 end

--- a/spec/lib/guardian_extensions_spec.rb
+++ b/spec/lib/guardian_extensions_spec.rb
@@ -25,6 +25,11 @@ describe DiscourseSolved::GuardianExtensions do
       expect(guardian.can_accept_answer?(topic, post)).to eq(false)
     end
 
+    it "returns false for private messages" do
+      topic.update!(user:, category_id: nil, archetype: Archetype.private_message)
+      expect(guardian.can_accept_answer?(topic, post)).to eq(false)
+    end
+
     it "returns false if accepted answers are not allowed" do
       SiteSetting.allow_solved_on_all_topics = false
       expect(guardian.can_accept_answer?(topic, post)).to eq(false)

--- a/spec/serializers/user_card_serializer_spec.rb
+++ b/spec/serializers/user_card_serializer_spec.rb
@@ -8,6 +8,8 @@ describe UserCardSerializer do
   let(:json) { serializer.as_json }
 
   it "accepted_answers serializes number of accepted answers" do
+    expect(serializer.as_json[:accepted_answers]).to eq(0)
+
     post1 = Fabricate(:post, user: user)
     DiscourseSolved.accept_answer!(post1, Discourse.system_user)
     expect(serializer.as_json[:accepted_answers]).to eq(1)
@@ -16,7 +18,17 @@ describe UserCardSerializer do
     DiscourseSolved.accept_answer!(post2, Discourse.system_user)
     expect(serializer.as_json[:accepted_answers]).to eq(2)
 
+    post3 = Fabricate(:post, user: user)
+    DiscourseSolved.accept_answer!(post3, Discourse.system_user)
+    expect(serializer.as_json[:accepted_answers]).to eq(3)
+
     DiscourseSolved.unaccept_answer!(post1)
+    expect(serializer.as_json[:accepted_answers]).to eq(2)
+
+    post2.topic.trash!(Discourse.system_user)
     expect(serializer.as_json[:accepted_answers]).to eq(1)
+
+    post3.topic.convert_to_private_message(Discourse.system_user)
+    expect(serializer.as_json[:accepted_answers]).to eq(0)
   end
 end


### PR DESCRIPTION
Pretty straightforward, this ensures we don't allow users to mark a post as a solution in a PM.

This also ensures we don't count solutions in topics that were converted to a PM.

Internal ref t/146766