### PR TITLE
FIX: Migration was only done for first batch

### DIFF
--- a/db/migrate/20250318024953_copy_solved_topic_custom_field_to_discourse_solved_solved_topics.rb
+++ b/db/migrate/20250318024953_copy_solved_topic_custom_field_to_discourse_solved_solved_topics.rb
@@ -6,7 +6,10 @@ class CopySolvedTopicCustomFieldToDiscourseSolvedSolvedTopics < ActiveRecord::Mi
   BATCH_SIZE = 10_000
 
   def up
-    max_id = DB.query_single("SELECT MAX(id) FROM topic_custom_fields").first
+    max_id =
+      DB.query_single(
+        "SELECT MAX(id) FROM topic_custom_fields WHERE topic_custom_fields.name = 'accepted_answer_post_id'",
+      ).first
     return unless max_id
 
     last_id = 0

--- a/db/migrate/20250325074111_copy_remaining_solved_topic_custom_field_to_discourse_solved_solved_topics.rb
+++ b/db/migrate/20250325074111_copy_remaining_solved_topic_custom_field_to_discourse_solved_solved_topics.rb
@@ -8,7 +8,10 @@ class CopyRemainingSolvedTopicCustomFieldToDiscourseSolvedSolvedTopics < ActiveR
   BATCH_SIZE = 5000
 
   def up
-    max_id = DB.query_single("SELECT MAX(id) FROM topic_custom_fields").first
+    max_id =
+      DB.query_single(
+        "SELECT MAX(id) FROM topic_custom_fields WHERE topic_custom_fields.name = 'accepted_answer_post_id'",
+      ).first
     return unless max_id
 
     last_id = 0


### PR DESCRIPTION
https://github.com/discourse/discourse-solved/pull/342 was deployed and observed to only have 5000 (batch size) migrated. This is an error in migration where the ids had a gap between the batch.

This PR changes the migration to just loop through all topic custom fields with each loop increasing by batch size.