### PR TITLE
UX: Better alignment and gaps for marked solved by

### DIFF
--- a/assets/javascripts/discourse/initializers/extend-for-solved-button.js
+++ b/assets/javascripts/discourse/initializers/extend-for-solved-button.js
@@ -42,12 +42,14 @@ function initializeWithApi(api) {
           const solvedQuote = `
             <aside class='quote accepted-answer' data-post="${topic.get("accepted_answer").post_number}" data-topic="${topic.id}">
               <div class='title ${hasExcerpt ? "" : "title-only"}'>
-                <div class="accepted-answer--solver">
-                  ${topic.solvedByHtml}
-                <\/div>
-                <div class="accepted-answer--accepter">
-                  ${topic.accepterHtml}
-                <\/div>
+                <div class="accepted-answer--solver-accepter">
+                  <div class="accepted-answer--solver">
+                    ${topic.solvedByHtml}
+                  <\/div>
+                  <div class="accepted-answer--accepter">
+                    ${topic.accepterHtml}
+                  <\/div>
+                </div>
                 <div class="quote-controls"><\/div>
               </div>
               ${excerpt}

--- a/assets/stylesheets/solutions.scss
+++ b/assets/stylesheets/solutions.scss
@@ -65,11 +65,16 @@ $solved-color: green;
 aside.quote.accepted-answer {
   .title {
     display: flex;
-    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: flex-start;
+  }
 
-    &.title-only {
-      padding: 12px;
-    }
+  .accepted-answer--solver-accepter {
+    display: flex;
+    flex-wrap: wrap;
+    flex: 1;
+    min-width: 0;
+    gap: 0.25em;
   }
 
   .accepted-answer--solver {
@@ -78,19 +83,14 @@ aside.quote.accepted-answer {
 
   .accepted-answer--accepter {
     font-size: var(--font-down-1);
-    margin-left: auto;
+    width: 100%;
+    flex-basis: auto;
     margin-top: auto;
-  }
+    margin-bottom: auto;
+    margin-right: 0.25em;
 
-  @media screen and (max-width: 768px) {
-    .accepted-answer--accepter {
-      width: 100%;
-      margin-top: 0.25em;
-      order: 3;
-    }
-
-    .quote-controls {
-      order: 2;
+    @media (min-width: 480px) {
+      width: auto;
     }
   }
 }


### PR DESCRIPTION
There are some small visual bugs now for the new "Marked solved by":

<img width="324" alt="Screenshot 2025-03-26 at 1 49 59 AM" src="https://github.com/user-attachments/assets/e1ca1faa-962e-43a6-be81-36eb40f5b6d3" />
<img width="316" alt="Screenshot 2025-03-26 at 1 51 11 AM" src="https://github.com/user-attachments/assets/0464c358-37f5-41f6-98f0-65a914d9326e" />

This PR fixes them.


https://github.com/user-attachments/assets/550d1746-ac5b-404d-82d1-c2c52828a745

