### PR TITLE
UX: fix misalignment for non-admin and anon + move to variable use

### DIFF
--- a/assets/stylesheets/solutions.scss
+++ b/assets/stylesheets/solutions.scss
@@ -38,8 +38,8 @@ $solved-color: var(--success);
 .post-controls span.accepted-text {
   display: inline-flex;
   align-items: center;
-  gap: .25em;
-  padding: 0 .5rem;
+  gap: 0.25em;
+  padding: 0 0.5rem;
   font-size: var(--font-up-1);
   height: 100%;
 }

--- a/assets/stylesheets/solutions.scss
+++ b/assets/stylesheets/solutions.scss
@@ -1,4 +1,4 @@
-$solved-color: green;
+$solved-color: var(--success);
 
 .select-kit {
   &.solved-status-filter {
@@ -36,17 +36,12 @@ $solved-color: green;
 }
 
 .post-controls span.accepted-text {
-  padding: 8px 10px;
-  font-size: $font-up-1;
-
-  span {
-    display: inline-block;
-    padding: 8px 1px;
-  }
-
-  .accepted-label {
-    margin-left: 7px;
-  }
+  display: inline-flex;
+  align-items: center;
+  gap: .25em;
+  padding: 0 .5rem;
+  font-size: var(--font-up-1);
+  height: 100%;
 }
 
 .mobile-view .solved-panel {


### PR DESCRIPTION
Padding around the span version can cause misalignment. Also moved some old variables over to the current default ones and moved away from px spacing.

| Before | After |
|--------|--------|
| ![CleanShot 2025-03-26 at 16 15 24](https://github.com/user-attachments/assets/7bac0768-f6af-4d6a-a5a2-1d49964aeb5a) | ![CleanShot 2025-03-26 at 16 13 57@2x](https://github.com/user-attachments/assets/d916d884-dd64-4e75-bfb4-f6a181a9173b) |
