### PR TITLE
DEV: Add class to solve topic-status

### DIFF
--- a/assets/javascripts/discourse/connectors/after-topic-status/solved-status.gjs
+++ b/assets/javascripts/discourse/connectors/after-topic-status/solved-status.gjs
@@ -8,7 +8,7 @@ const SolvedStatus = <template>
   ~}}
     <span
       title={{i18n "topic_statuses.solved.help"}}
-      class="topic-status"
+      class="topic-status solved"
     >{{icon "far-square-check"}}</span>
   {{~else if
     (and


### PR DESCRIPTION
Preparing for https://github.com/discourse/discourse/pull/32082, which switches core to use the modern TopicStatus component everywhere