### PR TITLE
FIX: Exclude deleted topics and posts as solution in user summary

### DIFF
--- a/lib/discourse_solved/user_summary_extension.rb
+++ b/lib/discourse_solved/user_summary_extension.rb
@@ -5,8 +5,9 @@ module DiscourseSolved::UserSummaryExtension
 
   def solved_count
     DiscourseSolved::SolvedTopic
-      .joins("JOIN posts ON posts.id = discourse_solved_solved_topics.answer_post_id")
-      .where(posts: { user_id: @user.id })
+      .joins(answer_post: :user, topic: {})
+      .where(posts: { user_id: @user.id, deleted_at: nil })
+      .where(topics: { archetype: Archetype.default, deleted_at: nil })
       .count
   end
 end

--- a/spec/models/user_summary_spec.rb
+++ b/spec/models/user_summary_spec.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 describe UserSummary do
+  fab!(:admin)
+
   describe "solved_count" do
     it "indicates the number of times a user's post is a topic's solution" do
       topic = Fabricate(:topic)
       Fabricate(:post, topic:)
       user = Fabricate(:user)
-      admin = Fabricate(:admin)
       post = Fabricate(:post, topic:, user:)
 
       user_summary = UserSummary.new(user, Guardian.new)
@@ -19,6 +20,34 @@ describe UserSummary do
 
       expect(user_summary.solved_count).to eq(1)
       expect(admin_summary.solved_count).to eq(0)
+    end
+
+    it "excludes deleted topics" do
+      topic = Fabricate(:topic)
+      Fabricate(:post, topic:)
+      user = Fabricate(:user)
+      post = Fabricate(:post, topic:, user:)
+
+      user_summary = UserSummary.new(user, Guardian.new)
+      DiscourseSolved.accept_answer!(post, admin)
+
+      topic.update!(deleted_at: Time.zone.now)
+
+      expect(user_summary.solved_count).to eq(0)
+    end
+
+    it "excludes deleted posts" do
+      topic = Fabricate(:topic)
+      Fabricate(:post, topic:)
+      user = Fabricate(:user)
+      post = Fabricate(:post, topic:, user:)
+
+      user_summary = UserSummary.new(user, Guardian.new)
+      DiscourseSolved.accept_answer!(post, admin)
+
+      post.update!(deleted_at: Time.zone.now)
+
+      expect(user_summary.solved_count).to eq(0)
     end
   end
 end


### PR DESCRIPTION
Follow up to https://github.com/discourse/discourse-solved/pull/352

The user summary solutions count is more than it should be because of deleted topics and posts.