### PR TITLE
FIX: Solutions directory item was using post creation instead of solved

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -295,7 +295,7 @@ after_initialize do
       FROM discourse_solved_solved_topics AS st
       JOIN posts AS p
          ON p.id = st.answer_post_id
-        AND COALESCE(p.created_at, :since) > :since
+        AND COALESCE(st.created_at, :since) > :since
         AND p.deleted_at IS NULL
       JOIN topics AS t
          ON t.id = st.topic_id

--- a/spec/models/directory_item_spec.rb
+++ b/spec/models/directory_item_spec.rb
@@ -6,10 +6,10 @@ describe DirectoryItem, type: :model do
     fab!(:admin)
 
     fab!(:topic1) { Fabricate(:topic, archetype: "regular", user:) }
-    fab!(:topic_post1) { Fabricate(:post, topic: topic1, user:) }
+    fab!(:topic_post1) { Fabricate(:post, topic: topic1, user:, created_at: 10.years.ago) }
 
     fab!(:topic2) { Fabricate(:topic, archetype: "regular", user:) }
-    fab!(:topic_post2) { Fabricate(:post, topic: topic2, user:) }
+    fab!(:topic_post2) { Fabricate(:post, topic: topic2, user:, created_at: 10.years.ago) }
 
     fab!(:pm) { Fabricate(:topic, archetype: "private_message", user:, category_id: nil) }
     fab!(:pm_post) { Fabricate(:post, topic: pm, user:) }
@@ -97,7 +97,7 @@ describe DirectoryItem, type: :model do
       expect(
         DirectoryItem.find_by(
           user_id: user.id,
-          period_type: DirectoryItem.period_types[:all],
+          period_type: DirectoryItem.period_types[:daily],
         ).solutions,
       ).to eq(1)
     end


### PR DESCRIPTION
Earlier on in the migration, the update of the user directory query was erroneously switched to use post creation date instead of the date the post was solved.

This PR fixes that.