### PR TITLE
FIX: User directory for solutions should update when value changes from positive value to zero

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -290,33 +290,34 @@ after_initialize do
   end
 
   query = <<~SQL
+    UPDATE directory_items di
+       SET solutions = 0
+     WHERE di.period_type = :period_type AND di.solutions IS NOT NULL;
+
     WITH x AS (
-      SELECT users.id AS user_id,
-             COUNT(DISTINCT st.topic_id) FILTER (WHERE
-               st.topic_id IS NOT NULL AND
-               t.id IS NOT NULL AND
-               t.archetype <> 'private_message' AND
-               t.deleted_at IS NULL AND
-               p.deleted_at IS NULL
-             ) AS solutions
-      FROM users
-      LEFT JOIN posts p ON p.user_id = users.id
-      LEFT JOIN discourse_solved_solved_topics st
-             ON st.answer_post_id = p.id
-             AND st.created_at >= :since
-      LEFT JOIN topics t ON t.id = st.topic_id
-      WHERE users.id > 0
-        AND users.active
-        AND users.silenced_till IS NULL
-        AND users.suspended_till IS NULL
-      GROUP BY users.id
+      SELECT p.user_id, COUNT(DISTINCT st.id) AS solutions
+      FROM discourse_solved_solved_topics AS st
+      JOIN posts AS p
+         ON p.id = st.answer_post_id
+        AND COALESCE(st.created_at, :since) > :since
+        AND p.deleted_at IS NULL
+      JOIN topics AS t
+         ON t.id = st.topic_id
+        AND t.archetype <> 'private_message'
+        AND t.deleted_at IS NULL
+      JOIN users AS u
+         ON u.id = p.user_id
+      WHERE u.id > 0
+        AND u.active
+        AND u.silenced_till IS NULL
+        AND u.suspended_till IS NULL
+      GROUP BY p.user_id
     )
     UPDATE directory_items di
-    SET solutions = x.solutions
-    FROM x
-    WHERE x.user_id = di.user_id
-      AND di.period_type = :period_type
-      AND di.solutions <> x.solutions
+       SET solutions = x.solutions
+      FROM x
+     WHERE x.user_id = di.user_id
+       AND di.period_type = :period_type;
   SQL
 
   add_directory_column("solutions", query:)

--- a/plugin.rb
+++ b/plugin.rb
@@ -292,20 +292,21 @@ after_initialize do
   query = <<~SQL
     WITH x AS (
       SELECT users.id AS user_id,
-             COUNT(DISTINCT CASE WHEN
+             COUNT(DISTINCT st.topic_id) FILTER (WHERE
                st.topic_id IS NOT NULL AND
                t.id IS NOT NULL AND
                t.archetype <> 'private_message' AND
                t.deleted_at IS NULL AND
                p.deleted_at IS NULL
-             THEN st.topic_id ELSE NULL END) AS solutions
+             ) AS solutions
       FROM users
       LEFT JOIN posts p ON p.user_id = users.id
       LEFT JOIN discourse_solved_solved_topics st
              ON st.answer_post_id = p.id
              AND st.created_at >= :since
       LEFT JOIN topics t ON t.id = st.topic_id
-      WHERE users.active
+      WHERE users.id > 0
+        AND users.active
         AND users.silenced_till IS NULL
         AND users.suspended_till IS NULL
       GROUP BY users.id

--- a/spec/models/directory_item_spec.rb
+++ b/spec/models/directory_item_spec.rb
@@ -101,5 +101,32 @@ describe DirectoryItem, type: :model do
         ).solutions,
       ).to eq(1)
     end
+
+    context "when refreshing across dates" do
+      it "updates the user's solution count from 1 to 0" do
+        freeze_time 40.days.ago
+        DiscourseSolved.accept_answer!(topic_post1, Discourse.system_user)
+
+        DirectoryItem.refresh!
+
+        expect(
+          DirectoryItem.find_by(
+            user_id: user.id,
+            period_type: DirectoryItem.period_types[:monthly],
+          ).solutions,
+        ).to eq(1)
+
+        unfreeze_time
+
+        DirectoryItem.refresh!
+
+        expect(
+          DirectoryItem.find_by(
+            user_id: user.id,
+            period_type: DirectoryItem.period_types[:monthly],
+          ).solutions,
+        ).to eq(0)
+      end
+    end
   end
 end


### PR DESCRIPTION
Special thanks to [Moin](https://meta.discourse.org/u/moin/summary) for pointing this out.

### Bug

If John created a post which is a solution in March, the user directory would show that John solution = 1.

In April, if John has not solved a topic, he would still have solution = 1 in the user directory.

Screenshot to user directory /u (does not show bug, just a reference):
<img width="500" alt="Screenshot 2025-06-06 at 11 35 32 PM" src="https://github.com/user-attachments/assets/818aa79f-e66e-40d2-8c27-102c0e04758f" />

### Fix

The directory column query needs to include users with 0 solutions, so that the value would be updated.