### PR TITLE
FIX: Use SolvedTopics to list posts in /activity/solved instead of user actions

### DIFF
--- a/app/controllers/discourse_solved/solved_topics_controller.rb
+++ b/app/controllers/discourse_solved/solved_topics_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class DiscourseSolved::SolvedTopicsController < ::ApplicationController
+  requires_plugin DiscourseSolved::PLUGIN_NAME
+
+  def by_user
+    params.permit(:username)
+    user =
+      fetch_user_from_params(
+        include_inactive:
+          current_user.try(:staff?) || (current_user && SiteSetting.show_inactive_accounts),
+      )
+    raise Discourse::NotFound unless guardian.public_can_see_profiles?
+    raise Discourse::NotFound unless guardian.can_see_profile?(user)
+
+    offset = [0, params[:offset].to_i].max
+    limit = params.fetch(:limit, 30).to_i
+
+    posts =
+      Post
+        .joins(
+          "INNER JOIN discourse_solved_solved_topics ON discourse_solved_solved_topics.answer_post_id = posts.id",
+        )
+        .joins(:topic)
+        .where(user_id: user.id, deleted_at: nil)
+        .where(topics: { archetype: Archetype.default, deleted_at: nil })
+        .includes(:user, topic: %i[category tags])
+        .order("discourse_solved_solved_topics.created_at DESC")
+        .offset(offset)
+        .limit(limit)
+
+    render_serialized(posts, DiscourseSolved::SolvedPostSerializer, root: "user_solved_posts")
+  end
+end

--- a/app/serializers/discourse_solved/solved_post_serializer.rb
+++ b/app/serializers/discourse_solved/solved_post_serializer.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+class DiscourseSolved::SolvedPostSerializer < ApplicationSerializer
+  attributes :created_at,
+             :archived,
+             :avatar_template,
+             :category_id,
+             :closed,
+             :cooked,
+             :excerpt,
+             :name,
+             :post_id,
+             :post_number,
+             :post_type,
+             :raw,
+             :slug,
+             :topic_id,
+             :topic_title,
+             :truncated,
+             :url,
+             :user_id,
+             :username
+
+  def archived
+    object.topic.archived
+  end
+
+  def avatar_template
+    object.user&.avatar_template
+  end
+
+  def category_id
+    object.topic.category_id
+  end
+
+  def closed
+    object.topic.closed
+  end
+
+  def excerpt
+    @excerpt ||= PrettyText.excerpt(cooked, 300, keep_emoji_images: true)
+  end
+
+  def name
+    object.user&.name
+  end
+
+  def include_name?
+    SiteSetting.enable_names?
+  end
+
+  def post_id
+    object.id
+  end
+
+  def slug
+    Slug.for(object.topic.title)
+  end
+
+  def include_slug?
+    object.topic.title.present?
+  end
+
+  def topic_title
+    object.topic.title
+  end
+
+  def truncated
+    true
+  end
+
+  def include_truncated?
+    cooked.length > 300
+  end
+
+  def url
+    "#{Discourse.base_url}#{object.url}"
+  end
+
+  def user_id
+    object.user_id
+  end
+
+  def username
+    object.user&.username
+  end
+end

--- a/assets/javascripts/discourse/routes/user-activity-solved.js
+++ b/assets/javascripts/discourse/routes/user-activity-solved.js
@@ -1,15 +1,119 @@
-import UserActivityStreamRoute from "discourse/routes/user-activity-stream";
+import { tracked } from "@glimmer/tracking";
+import EmberObject from "@ember/object";
+import { service } from "@ember/service";
+import { Promise } from "rsvp";
+import { ajax } from "discourse/lib/ajax";
+import DiscourseRoute from "discourse/routes/discourse";
 import { i18n } from "discourse-i18n";
 
-export default class UserActivitySolved extends UserActivityStreamRoute {
-  userActionType = 15;
-  noContentHelpKey = "solved.no_solutions";
+class SolvedPostsStream extends EmberObject {
+  @tracked content = [];
+  @tracked loading = false;
+  @tracked loaded = false;
+  @tracked itemsLoaded = 0;
+  @tracked canLoadMore = true;
+
+  constructor(args) {
+    super(args);
+    this.username = args.username;
+    this.siteCategories = args.siteCategories;
+  }
+
+  get noContent() {
+    return this.loaded && this.content.length === 0;
+  }
+
+  findItems() {
+    if (this.loading || !this.canLoadMore) {
+      return Promise.resolve();
+    }
+
+    this.set("loading", true);
+
+    const limit = 20;
+    return ajax(
+      `/solution/by_user.json?username=${this.username}&offset=${this.itemsLoaded}&limit=${limit}`
+    )
+      .then((result) => {
+        const userSolvedPosts = result.user_solved_posts || [];
+
+        if (userSolvedPosts.length === 0) {
+          this.set("canLoadMore", false);
+          return;
+        }
+
+        const posts = userSolvedPosts.map((p) => {
+          const post = EmberObject.create(p);
+          post.set("titleHtml", post.topic_title);
+          post.set("postUrl", post.url);
+
+          if (post.category_id && this.siteCategories) {
+            post.set(
+              "category",
+              this.siteCategories.find((c) => c.id === post.category_id)
+            );
+          }
+          return post;
+        });
+
+        // Add to existing content
+        if (this.content.pushObjects) {
+          this.content.pushObjects(posts);
+        } else {
+          this.content = this.content.concat(posts);
+        }
+
+        this.set("itemsLoaded", this.itemsLoaded + userSolvedPosts.length);
+
+        if (userSolvedPosts.length < limit) {
+          this.set("canLoadMore", false);
+        }
+      })
+      .finally(() => {
+        this.setProperties({
+          loaded: true,
+          loading: false,
+        });
+      });
+  }
+}
+
+export default class UserActivitySolved extends DiscourseRoute {
+  @service site;
+  @service currentUser;
+
+  model() {
+    const user = this.modelFor("user");
+
+    const stream = new SolvedPostsStream({
+      username: user.username,
+      siteCategories: this.site.categories,
+    });
+
+    return stream.findItems().then(() => {
+      return {
+        stream,
+        emptyState: this.emptyState(),
+      };
+    });
+  }
+
+  setupController(controller, model) {
+    controller.setProperties({
+      model,
+      emptyState: this.emptyState(),
+    });
+  }
+
+  renderTemplate() {
+    this.render("user-activity-solved");
+  }
 
   emptyState() {
     const user = this.modelFor("user");
 
     let title, body;
-    if (this.isCurrentUser(user)) {
+    if (this.currentUser && user.id === this.currentUser.id) {
       title = i18n("solved.no_solved_topics_title");
       body = i18n("solved.no_solved_topics_body");
     } else {

--- a/assets/javascripts/discourse/templates/user-activity-solved.gjs
+++ b/assets/javascripts/discourse/templates/user-activity-solved.gjs
@@ -1,0 +1,19 @@
+import RouteTemplate from "ember-route-template";
+import UserStream from "discourse/components/user-stream";
+
+export default RouteTemplate(
+  <template>
+    {{#if @controller.model.stream.noContent}}
+      <div class="empty-state">
+        <span class="empty-state-title">
+          {{@controller.model.emptyState.title}}
+        </span>
+        <div class="empty-state-body">
+          {{{@controller.model.emptyState.body}}}
+        </div>
+      </div>
+    {{/if}}
+
+    <UserStream @stream={{@controller.model.stream}} />
+  </template>
+);

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@
 DiscourseSolved::Engine.routes.draw do
   post "/accept" => "answer#accept"
   post "/unaccept" => "answer#unaccept"
+
+  get "/by_user" => "solved_topics#by_user"
 end
 
 Discourse::Application.routes.draw { mount ::DiscourseSolved::Engine, at: "solution" }

--- a/spec/system/solved_spec.rb
+++ b/spec/system/solved_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-describe "About page", type: :system do
+describe "Solved", type: :system do
   fab!(:admin)
   fab!(:solver) { Fabricate(:user) }
   fab!(:accepter) { Fabricate(:user) }
   fab!(:topic) { Fabricate(:post, user: admin).topic }
-  fab!(:post1) { Fabricate(:post, topic:, user: solver, cooked: "The answer is 42") }
+  fab!(:solver_post) { Fabricate(:post, topic:, user: solver, cooked: "The answer is 42") }
   let(:topic_page) { PageObjects::Pages::Topic.new }
 
   before do
@@ -38,5 +38,14 @@ describe "About page", type: :system do
         expect(topic_page.find("blockquote")).to have_content("The answer is 42")
       end
     end
+  end
+
+  it "shows the solved post in user activity at /my/activity/solved" do
+    Fabricate(:solved_topic, topic:, answer_post: solver_post, accepter:)
+
+    sign_in(solver)
+    visit "/my/activity/solved"
+
+    expect(page.find(".post-list")).to have_content(solver_post.cooked)
   end
 end


### PR DESCRIPTION
In https://github.com/discourse/discourse-solved/pull/342 we moved solutions away from topic_custom_fields into proper tables, with the tables as the proper source of truth to a topic's solution.

The user's /my/activity/solved route uses user_actions which is not accurate, and a user has reported a bug where their solution is not reflected there (user actions are not a good representation of what a topic's solution is). 

This PR introduces 
- a new route to get solutions, and is mindful `hide_user_profiles_from_public` and such settings
- a new template that makes use of the `<UserStream>` to load posts safely

After fix:

| desc | 📸 |
|---|---|
| All activity for reference |  <img width="1118" alt="Screenshot 2025-06-26 at 5 34 18 PM" src="https://github.com/user-attachments/assets/a79c6b3c-f4d7-4c06-96c0-820a050127a8" /> |
| no solved |  <img width="1118" alt="Screenshot 2025-06-26 at 5 34 23 PM" src="https://github.com/user-attachments/assets/2af9d75f-6514-4cef-8fdf-9d6d3882c72f" /> |
| solved with pagination |  <video src="https://github.com/user-attachments/assets/59542b2b-f1da-4323-93b1-83a189e04911"> |


