### PR TITLE
FIX: Exclude the first solution itself when checking if an existing solution

### DIFF
--- a/lib/discourse_solved/first_accepted_post_solution_validator.rb
+++ b/lib/discourse_solved/first_accepted_post_solution_validator.rb
@@ -12,7 +12,7 @@ module DiscourseSolved
 
       !DiscourseSolved::SolvedTopic
         .joins(:answer_post)
-        .where("posts.user_id = ?", post.user_id)
+        .where("posts.user_id = ? AND posts.id != ?", post.user_id, post.id)
         .exists?
     end
   end

--- a/spec/lib/first_accepted_post_solution_validator_spec.rb
+++ b/spec/lib/first_accepted_post_solution_validator_spec.rb
@@ -3,59 +3,41 @@
 describe DiscourseSolved::FirstAcceptedPostSolutionValidator do
   fab!(:user_tl1) { Fabricate(:user, trust_level: TrustLevel[1], refresh_auto_groups: true) }
 
-  context "when user is under max trust level" do
-    context "with no post accepted yet" do
-      it "validates the post" do
-        post_1 = create_post(user: user_tl1)
-        expect(described_class.check(post_1, trust_level: TrustLevel[2])).to eq(true)
-      end
-    end
-
-    context "with already had accepted posts" do
-      before do
-        accepted_post = create_post(user: user_tl1)
-        DiscourseSolved.accept_answer!(accepted_post, Discourse.system_user)
-      end
-
-      it "doesn’t validate the post" do
-        post_1 = create_post(user: user_tl1)
-        expect(described_class.check(post_1, trust_level: TrustLevel[2])).to eq(false)
-      end
-    end
-  end
-
-  context "when a user is above or equal max trust level" do
-    context "with no post accepted yet" do
-      it "doesn’t validate the post" do
-        post_1 = create_post(user: user_tl1)
-        expect(described_class.check(post_1, trust_level: TrustLevel[1])).to eq(false)
-      end
-    end
-
-    context "when a post is already accepted" do
-      before do
-        accepted_post = create_post(user: user_tl1)
-        DiscourseSolved.accept_answer!(accepted_post, Discourse.system_user)
-      end
-
-      it "doesn’t validate the post" do
-        post_1 = create_post(user: user_tl1)
-        expect(described_class.check(post_1, trust_level: TrustLevel[1])).to eq(false)
-      end
-    end
-  end
-
-  context "when using any trust level" do
+  context "when trust level is 'any'" do
     it "validates the post" do
-      post_1 = create_post(user: user_tl1)
-      expect(described_class.check(post_1, trust_level: "any")).to eq(true)
+      post = Fabricate(:post, user: user_tl1)
+      DiscourseSolved.accept_answer!(post, Discourse.system_user)
+
+      expect(described_class.check(post, trust_level: "any")).to eq(true)
     end
 
     it "invalidates if post user already has an accepted post" do
-      accepted_post = create_post(user: user_tl1)
-      DiscourseSolved.accept_answer!(accepted_post, Discourse.system_user)
-      post_1 = create_post(user: user_tl1)
-      expect(described_class.check(post_1, trust_level: "any")).to eq(false)
+      previously_accepted_post = Fabricate(:post, user: user_tl1)
+      DiscourseSolved.accept_answer!(previously_accepted_post, Discourse.system_user)
+
+      newly_accepted_post = Fabricate(:post, user: user_tl1)
+      DiscourseSolved.accept_answer!(newly_accepted_post, Discourse.system_user)
+
+      expect(described_class.check(newly_accepted_post, trust_level: "any")).to eq(false)
+    end
+  end
+
+  context "with specified trust level that is not 'any'" do
+    # the automation indicates "users under this Trust Level will trigger this automation"
+
+    it "invalidates if the user is higher than or equal to the specified trust level" do
+      post = Fabricate(:post, user: user_tl1)
+      DiscourseSolved.accept_answer!(post, Discourse.system_user)
+
+      expect(described_class.check(post, trust_level: TrustLevel[0])).to eq(false)
+      expect(described_class.check(post, trust_level: TrustLevel[1])).to eq(false)
+    end
+
+    it "validates the post when user is under specified trust level" do
+      post = Fabricate(:post, user: user_tl1)
+      DiscourseSolved.accept_answer!(post, Discourse.system_user)
+
+      expect(described_class.check(post, trust_level: TrustLevel[2])).to eq(true)
     end
   end
 


### PR DESCRIPTION
When fixing https://github.com/discourse/discourse-solved/pull/377, we uncovered another bug where the existing check does not remember to exclude the first solution itself.

This PR 
- makes sure to exclude the first solution when checking for an existing solution
- better tests -- the existing test does not accept the post prior to making the check.