### PR TITLE
TEMP: skip tests due to core change

### DIFF
--- a/test/javascripts/acceptance/user-activity-solved-test.js
+++ b/test/javascripts/acceptance/user-activity-solved-test.js
@@ -1,5 +1,5 @@
 import { visit } from "@ember/test-helpers";
-import { test } from "qunit";
+import { skip } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { i18n } from "discourse-i18n";
 
@@ -14,7 +14,9 @@ acceptance(
       );
     });
 
-    test("When looking at own activity", async function (assert) {
+    /* disabled temporarily for core updates https://github.com/discourse/discourse/pull/33455 */
+
+    skip("When looking at own activity", async function (assert) {
       await visit(`/u/eviltrout/activity/solved`);
 
       assert
@@ -25,7 +27,7 @@ acceptance(
         .hasText(i18n("solved.no_solved_topics_body"));
     });
 
-    test("When looking at another user's activity", async function (assert) {
+    skip("When looking at another user's activity", async function (assert) {
       await visit(`/u/charlie/activity/solved`);
 
       assert.dom("div.empty-state span.empty-state-title").hasText(


### PR DESCRIPTION
The changes here break these tests, https://github.com/discourse/discourse/pull/33455

Will update once that's merged 