### PR TITLE
DEV: re-enable and update empty state tests

### DIFF
--- a/test/javascripts/acceptance/user-activity-solved-test.js
+++ b/test/javascripts/acceptance/user-activity-solved-test.js
@@ -1,5 +1,5 @@
 import { visit } from "@ember/test-helpers";
-import { skip } from "qunit";
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { i18n } from "discourse-i18n";
 
@@ -14,28 +14,26 @@ acceptance(
       );
     });
 
-    /* disabled temporarily for core updates https://github.com/discourse/discourse/pull/33455 */
-
-    skip("When looking at own activity", async function (assert) {
+    test("When looking at own activity", async function (assert) {
       await visit(`/u/eviltrout/activity/solved`);
 
       assert
-        .dom("div.empty-state span.empty-state-title")
+        .dom(".empty-state .empty-state-title")
         .hasText(i18n("solved.no_solved_topics_title"));
       assert
-        .dom("div.empty-state div.empty-state-body")
+        .dom(".empty-state .empty-state-body")
         .hasText(i18n("solved.no_solved_topics_body"));
     });
 
-    skip("When looking at another user's activity", async function (assert) {
+    test("When looking at another user's activity", async function (assert) {
       await visit(`/u/charlie/activity/solved`);
 
-      assert.dom("div.empty-state span.empty-state-title").hasText(
+      assert.dom(".empty-state .empty-state-title").hasText(
         i18n("solved.no_solved_topics_title_others", {
           username: "charlie",
         })
       );
-      assert.dom("div.empty-state div.empty-state-body").hasNoText();
+      assert.dom(".empty-state .empty-state-body").hasNoText();
     });
   }
 );

--- a/test/javascripts/acceptance/user-activity-solved-test.js
+++ b/test/javascripts/acceptance/user-activity-solved-test.js
@@ -18,22 +18,22 @@ acceptance(
       await visit(`/u/eviltrout/activity/solved`);
 
       assert
-        .dom(".empty-state .empty-state-title")
+        .dom(".empty-state .empty-state__title")
         .hasText(i18n("solved.no_solved_topics_title"));
       assert
-        .dom(".empty-state .empty-state-body")
+        .dom(".empty-state .empty-state__body")
         .hasText(i18n("solved.no_solved_topics_body"));
     });
 
     test("When looking at another user's activity", async function (assert) {
       await visit(`/u/charlie/activity/solved`);
 
-      assert.dom(".empty-state .empty-state-title").hasText(
+      assert.dom(".empty-state .empty-state__title").hasText(
         i18n("solved.no_solved_topics_title_others", {
           username: "charlie",
         })
       );
-      assert.dom(".empty-state .empty-state-body").hasNoText();
+      assert.dom(".empty-state .empty-state__body").hasNoText();
     });
   }
 );

--- a/test/javascripts/acceptance/user-activity-solved-test.js
+++ b/test/javascripts/acceptance/user-activity-solved-test.js
@@ -33,7 +33,7 @@ acceptance(
           username: "charlie",
         })
       );
-      assert.dom(".empty-state .empty-state__body").hasNoText();
+      assert.dom(".empty-state .empty-state__body").doesNotExist();
     });
   }
 );


### PR DESCRIPTION
Re-enables the tests disabled in 1d038963fdfa290dd77dc95371403d31eace5611, now that https://github.com/discourse/discourse/pull/33455 has been merged

minor change in behavior, as when there's no body text `.empty-state__body` no longer exists (used to render empty) 