### PR TITLE
A11Y: improve expand/collapse labeling on embedded solution post

### DIFF
--- a/assets/javascripts/discourse/components/solved-accepted-answer.gjs
+++ b/assets/javascripts/discourse/components/solved-accepted-answer.gjs
@@ -128,14 +128,17 @@ export default class SolvedAcceptedAnswer extends Component {
           <div class="quote-controls">
             <button
               aria-controls={{this.quoteId}}
-              aria-expanded={{this.expanded}}
+              aria-expanded={{if this.expanded "true" "false"}}
               class="quote-toggle btn-flat"
               type="button"
-            >
-              {{icon
-                (if this.expanded "chevron-up" "chevron-down")
-                title="post.expand_collapse"
+              aria-label={{if
+                this.expanded
+                (i18n "post.collapse")
+                (i18n "expand")
               }}
+              title={{if this.expanded (i18n "post.collapse") (i18n "expand")}}
+            >
+              {{icon (if this.expanded "chevron-up" "chevron-down")}}
             </button>
           </div>
         {{/if}}


### PR DESCRIPTION
This adds an aria-label based on the state of the button and also moves the title to the button rather than the icon. 

<img width="778" height="108" alt="image" src="https://github.com/user-attachments/assets/86138840-d52b-4c60-81fa-49040e76a6fd" />

<img width="774" height="151" alt="image" src="https://github.com/user-attachments/assets/e76f8234-103e-4e13-8f6e-235d9703a83b" />

I also noticed that `aria-expanded` was rendering as `aria-expanded=""` which isn't helpful, we need a true/false string as the examples show here: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-expanded